### PR TITLE
Add includeSuper property to @Canonical annotation

### DIFF
--- a/src/main/groovy/transform/Canonical.java
+++ b/src/main/groovy/transform/Canonical.java
@@ -129,4 +129,15 @@ public @interface Canonical {
      * the value of this attribute can be overridden within the more specific annotation.
      */
     String[] includes() default {};
+
+    /**
+     * Whether to include super in all transformations.
+     * Acts as if {@code EqualsAndHashCode.callSuper}, {@code ToString.includeSuper} and
+     * {@code TupleConstructor.includeSuperProperties} were all set to true.
+     *
+     * If the {@code @Canonical} behavior is customised by using it in conjunction with one of the more specific
+     * related annotations (i.e. {@code @ToString}, {@code @EqualsAndHashCode} or {@code @TupleConstructor}), then
+     * the value of this attribute can be overridden within the more specific annotation.
+     */
+    boolean includeSuper() default false;
 }

--- a/src/main/org/codehaus/groovy/transform/CanonicalASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/CanonicalASTTransformation.java
@@ -62,16 +62,17 @@ public class CanonicalASTTransformation extends AbstractASTTransformation {
             if (!checkNotInterface(cNode, MY_TYPE_NAME)) return;
             List<String> excludes = getMemberList(anno, "excludes");
             List<String> includes = getMemberList(anno, "includes");
+            boolean includeSuper = memberHasValue(anno, "includeSuper", true);
             if (!checkIncludeExclude(anno, excludes, includes, MY_TYPE_NAME)) return;
             if (!hasAnnotation(cNode, TupleConstructorASTTransformation.MY_TYPE)) {
-                createConstructor(cNode, false, true, false, false, false, false, excludes, includes, false);
+                createConstructor(cNode, false, true, false, includeSuper, false, false, excludes, includes, false);
             }
             if (!hasAnnotation(cNode, EqualsAndHashCodeASTTransformation.MY_TYPE)) {
-                createHashCode(cNode, false, false, false, excludes, includes);
-                createEquals(cNode, false, false, true, excludes, includes);
+                createHashCode(cNode, false, false, includeSuper, excludes, includes);
+                createEquals(cNode, false, includeSuper, true, excludes, includes);
             }
             if (!hasAnnotation(cNode, ToStringASTTransformation.MY_TYPE)) {
-                createToString(cNode, false, false, excludes, includes, false);
+                createToString(cNode, includeSuper, false, excludes, includes, false);
             }
         }
     }

--- a/src/test/org/codehaus/groovy/transform/CanonicalTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/CanonicalTransformTest.groovy
@@ -584,4 +584,56 @@ class CanonicalTransformTest extends GroovyShellTestCase {
         """
     }
 
+    void testToStringIncludingSuper() {
+        assert 'Bar(20, Foo(10))' == evaluate("""
+            import groovy.transform.*
+            @Canonical
+            class Foo {
+                int a
+            }
+            @Canonical(includeSuper = true)
+            class Bar extends Foo {
+                int b
+            }
+            new Bar(a:10, b:20).toString()
+        """)
+    }
+
+    void testEqualsAndHashCodeIncludingSuper() {
+        def objects = evaluate("""
+            import groovy.transform.*
+            @Canonical
+            class Foo {
+                int a
+            }
+            @Canonical(includeSuper = true)
+            class Bar extends Foo {
+                int b
+            }
+            [new Bar(a:10, b:20),
+            new Bar(a:20, b:20)]
+        """)
+
+        assert objects[0] != objects[1]
+        assert objects[0].hashCode() != objects[1].hashCode()
+    }
+
+    void testConstructorIncludingSuper() {
+        assertScript """
+            import groovy.transform.*
+            @Canonical
+            class Foo {
+                int a
+            }
+            @Canonical(includeSuper = true)
+            class Bar extends Foo {
+                int b
+            }
+
+            def bar = new Bar(10, 20)
+
+            assert bar.a == 10
+            assert bar.b == 20
+        """
+    }
 }


### PR DESCRIPTION
Hi,

This is something that came up in discussion at a recent London Groovy and Grails User Group meetup.  It's a bit annoying having to use the three separate AST transformations that make up @Canonical to include the super class in the transformation(s).  I had a look at extending the @Canonical implementation to support this and this is what I came up with.

This adds a property called includeSuper to @Canonical which has has the same effect as setting @EqualsAndHashCode.callSuper, @ToString.includeSuper and @TupleConstructor.includeSuperProperties to true.  I've tried to keep this as low impact as possible so it shouldn't do anything unexpected.

Is there anything I've overlooked here?

Andy Duncan