### PR TITLE
GROOVY-7425: Adding 'getBytes(Map parameters)' method to the URL class

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -709,7 +709,7 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
      * @param parameters connection parameters
      * @return the byte[] from that URL
      * @throws IOException if an IOException occurs.
-     * @since 2.4.1
+     * @since 2.4.4
      */
     public static byte[] getBytes(URL url, Map parameters) throws IOException {
         return IOGroovyMethods.getBytes(configuredInputStream(parameters, url));

--- a/src/main/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -694,6 +694,29 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Read the content of this URL and returns it as a byte[].
+     * The default connection parameters can be modified by adding keys to the
+     * <i>parameters map</i>:
+     * <ul>
+     * <li>connectTimeout : the connection timeout</li>
+     * <li>readTimeout : the read timeout</li>
+     * <li>useCaches : set the use cache property for the URL connection</li>
+     * <li>allowUserInteraction : set the user interaction flag for the URL connection</li>
+     * <li>requestProperties : a map of properties to be passed to the URL connection</li>
+     * </ul>
+     *
+     * @param url        URL to read content from
+     * @param parameters connection parameters
+     * @return the byte[] from that URL
+     * @throws IOException if an IOException occurs.
+     * @since 2.4.1
+     */
+    public static byte[] getBytes(URL url, Map parameters) throws IOException {
+        return IOGroovyMethods.getBytes(configuredInputStream(parameters, url));
+    }
+
+
+    /**
      * Write the bytes from the byte array to the File.
      *
      * @param file  the file to write to

--- a/src/test/org/codehaus/groovy/runtime/URLGetBytesTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/URLGetBytesTest.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2003-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.runtime
+
+/**
+ * Tests for {@link DefaultGroovyMethods} URL.getBytes() methods.
+ *
+ */
+class URLGetBytesTest extends GroovyTestCase {
+    void testGetBytesFromURLWithParameters() {
+        def url = new URL('http','groovy.codehaus.org',80, '/', new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL u) {
+                new DummyURLConnection(new URL('http://groovy.codehaus.org'))
+            }
+
+        })
+
+        assert url.bytes == 'Groovy'.bytes
+
+        shouldFail(SocketTimeoutException) {
+            url.getBytes(readTimeout:5)
+        }
+
+        shouldFail(SocketTimeoutException) {
+            url.getText(connectTimeout:5)
+        }
+
+        shouldFail(RuntimeException) {
+            url.getBytes(allowUserInteraction:true)
+        }
+
+        assert url.getBytes(useCaches:true) == 'Groovy cached'.bytes
+
+        assert url.getBytes(requestProperties:[a:'b']) == 'Groovy a:b'.bytes
+
+        assert url.getBytes(useCaches:true, requestProperties:[a:'b']) == 'Groovy cached a:b'.bytes
+
+        assert url.getBytes() == url.getBytes()
+
+        assert url.getBytes() == url.getBytes((Map)null)
+    }
+
+    private static class DummyURLConnection extends URLConnection {
+
+        boolean throwConnectTimeout = false
+        boolean throwReadTimeout = false
+        boolean useCache = false
+        boolean allowUserInteraction = false
+        def properties = [:]
+
+
+        DummyURLConnection(final URL url) {
+            super(url)
+        }
+
+        @Override
+        InputStream getInputStream() {
+            if (throwConnectTimeout) throw new SocketTimeoutException()
+            if (throwReadTimeout) throw new SocketTimeoutException()
+            if (allowUserInteraction) throw new RuntimeException('User interaction')
+            def string = useCache?'Groovy cached':'Groovy'
+            properties.each { k,v -> string = string + " $k:$v"}
+            new ByteArrayInputStream(string.bytes)
+        }
+
+        @Override
+        public void setAllowUserInteraction(boolean allowuserinteraction) {
+            allowUserInteraction = allowuserinteraction
+        }
+
+        @Override
+        void setConnectTimeout(int timeout) {
+            super.setConnectTimeout(timeout)
+            throwConnectTimeout = true
+        }
+
+        @Override
+        void setReadTimeout(int timeout) {
+            super.setReadTimeout(timeout)
+            throwReadTimeout = true
+        }
+
+        @Override
+        void setUseCaches(boolean usecaches) {
+            super.setUseCaches(usecaches)
+            useCache = true
+        }
+
+        @Override
+        void setRequestProperty(String key, String value) {
+            properties[key] = value
+        }
+
+
+        @Override
+        void connect() {
+        }
+
+    }
+}

--- a/src/test/org/codehaus/groovy/runtime/URLGetBytesTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/URLGetBytesTest.groovy
@@ -21,10 +21,10 @@ package org.codehaus.groovy.runtime
  */
 class URLGetBytesTest extends GroovyTestCase {
     void testGetBytesFromURLWithParameters() {
-        def url = new URL('http','groovy.codehaus.org',80, '/', new URLStreamHandler() {
+        def url = new URL('http','groovy-lang.org',80, '/', new URLStreamHandler() {
             @Override
             protected URLConnection openConnection(URL u) {
-                new DummyURLConnection(new URL('http://groovy.codehaus.org'))
+                new DummyURLConnection(new URL('http://groovy-lang.org'))
             }
 
         })
@@ -48,8 +48,6 @@ class URLGetBytesTest extends GroovyTestCase {
         assert url.getBytes(requestProperties:[a:'b']) == 'Groovy a:b'.bytes
 
         assert url.getBytes(useCaches:true, requestProperties:[a:'b']) == 'Groovy cached a:b'.bytes
-
-        assert url.getBytes() == url.getBytes()
 
         assert url.getBytes() == url.getBytes((Map)null)
     }

--- a/src/test/org/codehaus/groovy/runtime/URLGetBytesTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/URLGetBytesTest.groovy
@@ -1,17 +1,20 @@
 /*
- * Copyright 2003-2015 the original author or authors.
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
 package org.codehaus.groovy.runtime
 


### PR DESCRIPTION
Hi all, new contributor to groovy.lang
from https://issues.apache.org/jira/browse/GROOVY-7425

Let me know if there is anything that needs to be changed
