### PR TITLE
GROOVY-7338: URL getText(requestProperties) Map now accepts a GString

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -2047,9 +2047,9 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
             }
             if (parameters.containsKey("requestProperties")) {
                 @SuppressWarnings("unchecked")
-                Map<String, String> properties = (Map<String, String>) parameters.get("requestProperties");
-                for (Map.Entry<String, String> entry : properties.entrySet()) {
-                    connection.setRequestProperty(entry.getKey(), entry.getValue());
+                Map<String, CharSequence> properties = (Map<String, CharSequence>) parameters.get("requestProperties");
+                for (Map.Entry<String, CharSequence> entry : properties.entrySet()) {
+                    connection.setRequestProperty(entry.getKey(), entry.getValue().toString());
                 }
             }
 

--- a/src/test/org/codehaus/groovy/runtime/URLGetBytesTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/URLGetBytesTest.groovy
@@ -52,6 +52,11 @@ class URLGetBytesTest extends GroovyTestCase {
         assert url.getBytes(useCaches:true, requestProperties:[a:'b']) == 'Groovy cached a:b'.bytes
 
         assert url.getBytes() == url.getBytes((Map)null)
+
+        assert url.getBytes(requestProperties: [a:"b"]) == "Groovy a:b".bytes
+
+        def val = 'b'
+        assert url.getBytes(requestProperties: [a:"$val"]) == "Groovy a:b".bytes
     }
 
     private static class DummyURLConnection extends URLConnection {

--- a/src/test/org/codehaus/groovy/runtime/URLGetTextTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/URLGetTextTest.groovy
@@ -60,7 +60,9 @@ class URLGetTextTest extends GroovyTestCase {
         assert url.getText() == url.getText()
 
         assert url.getText() == url.getText((Map)null)
-        
+
+        def val = 'b'
+        assert url.getText(requestProperties: [a:"$val"]) == "Groovy a:b"
     }
 
     private static class DummyURLConnection extends URLConnection {


### PR DESCRIPTION
What do you guys think about this change for http://jira.codehaus.org/browse/GROOVY-7338, is in a similar location as my previous PR