### PR TITLE
Fix IDE integration instructions in README.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -83,13 +83,13 @@ If you want to launch one unit test, use this. <TestClassName> is like `groovy.G
 
 To build from IntelliJ IDEA:
 
-    gradlew jarAll idea
+    gradlew jar idea
 
 Then open the generated project in IDEA.
 
 To build from Eclipse:
 
-    gradlew jarAll eclipse
+    gradlew jar eclipse
 
 Then open the generated project and the generated subprojects in Eclipse. But be aware that Eclipse tends to be more limited in its ability to reproduce a Gradle build structure. The generated project files may contain a circular dependency which may or may not prevent Eclipse from using them. It depends on the Eclipse version, if this is an issue or not.
 


### PR DESCRIPTION
The README stated that you should run

    gradlew jarAll idea

before loading the project into IntelliJ IDEA. It seems, though, that the `jarAll`
task breaks the IDE integration and you can't run tests. Running

    gradlew jar idea

seems to work fine, so I've updated the README to reflect this.