### PR TITLE
Append the power assignment operator to the docs

### DIFF
--- a/src/spec/doc/core-operators.adoc
+++ b/src/spec/doc/core-operators.adoc
@@ -81,6 +81,7 @@ From the binary arithmetic operators we have seen above, certain of them are als
 * `*=`
 * `/=`
 * `%=`
+* `**=`
 
 Let's see them in action:
 

--- a/src/spec/doc/core-program-structure.adoc
+++ b/src/spec/doc/core-program-structure.adoc
@@ -51,7 +51,7 @@ import java.math.BigDecimal
 
 === Simple import
 
-A simple import is an import statement where you fully define the class name along with the package. For example the import statement ++import groovy.xml.MarkupBuilder++ in the code below is a simple import which directly refers to the a class inside a package.
+A simple import is an import statement where you fully define the class name along with the package. For example the import statement ++import groovy.xml.MarkupBuilder++ in the code below is a simple import which directly refers to a class inside a package.
 
 [source,groovy]
 ----

--- a/src/spec/test/OperatorsTest.groovy
+++ b/src/spec/test/OperatorsTest.groovy
@@ -89,6 +89,11 @@ class OperatorsTest extends CompilableTestSupport {
         e %= 3
 
         assert e == 1
+
+        def f = 3
+        f **= 2
+
+        assert f == 9
         // end::binary_assign_operators[]
     }
 


### PR DESCRIPTION
The power assignment arithmetic operator was appended to the docs under the `Assignment arithmetic operators` section. Additionally, the corresponding test was included inside the `/src/spec/test/OperatorsTest.groovy` file.