### PR TITLE
Include the correct test in `Method resolution`

### DIFF
--- a/src/spec/doc/core-semantics.adoc
+++ b/src/spec/doc/core-semantics.adoc
@@ -1308,7 +1308,7 @@ not in such a case, `@TypeChecked` comes handy:
 
 [source,groovy]
 ----
-include::{projectdir}/src/spec/test/typing/TypeCheckingTest.groovy[tags=method_not_type_checked,indent=0]
+include::{projectdir}/src/spec/test/typing/TypeCheckingTest.groovy[tags=method_type_checked,indent=0]
 ----
 <1> `printLine` is this time a compile-time error
 


### PR DESCRIPTION
The tag's name was fixed in order to include the correct test in the
`Method resolution` subsection inside the `core-semantics.adoc` file.