### PR TITLE
GROOVY-5185: Cast operator precedence is incorrect

### DIFF
--- a/src/main/org/codehaus/groovy/antlr/groovy.g
+++ b/src/main/org/codehaus/groovy/antlr/groovy.g
@@ -2320,10 +2320,10 @@ commandArgument
 // in contexts where we know we have an expression.  It allows general Java-type expressions.
 expression[int lc_stmt]
     :
-        (LPAREN typeSpec[true] RPAREN expression[lc_stmt])=>
-            lp:LPAREN^ {#lp.setType(TYPECAST);} typeSpec[true] RPAREN!
-            expression[lc_stmt]
-    |
+//        (LPAREN typeSpec[true] RPAREN expression[lc_stmt])=>
+//            lp:LPAREN^ {#lp.setType(TYPECAST);} typeSpec[true] RPAREN!
+//            expression[lc_stmt]
+//    |
        (LPAREN nls IDENT (COMMA nls IDENT)* RPAREN ASSIGN) =>
         m:multipleAssignment[lc_stmt] {#expression=#m;}
     |   assignmentExpression[lc_stmt]

--- a/src/test/gls/syntax/ParsingTest.groovy
+++ b/src/test/gls/syntax/ParsingTest.groovy
@@ -53,6 +53,16 @@ public class ParsingTest extends gls.CompilableTestSupport {
         assert val4.class.componentType == short
     }
 
+    void testCastPrecedence_Groovy4421_Groovy5185() {
+        def i = (int)1/(int)2
+        assert i.class==BigDecimal
+
+        def result = (long)10.7 % 3L
+        assert result == 1 && result instanceof Long
+
+        assert '42' == (String) { -> 40 + 2 }.call()
+    }
+
     void testExpressionParsingWithCastInFrontOfAMap() {
         shouldCompile """
             def m = (Map)[a:{ "foo"; println 'bar' }]


### PR DESCRIPTION
I think this rolls back the prod code changes from GROOVY-2605 but we may have done other changes in the meantime since the tests for the issue seem to all still pass.