### PR TITLE
Update core-program-structure.adoc

### DIFF
--- a/src/spec/doc/core-program-structure.adoc
+++ b/src/spec/doc/core-program-structure.adoc
@@ -56,7 +56,9 @@ Default imports are the imports that Groovy language provides by default. For ex
 include::{projectdir}/src/spec/test/PackageTest.groovy[tags=default_import,indent=0]
 ----
 
-The same code in Java needs an import statement to `Date` class like this: ++import java.util.Date++. Groovy by default imports these classes for you. There are six packages that groovy imports for you, they are:
+The same code in Java needs an import statement to `Date` class like this: ++import java.util.Date++. Groovy by default imports these classes for you. 
+
+The below imports are added by groovy for you:
 
 [source,groovy]
 ----
@@ -70,6 +72,8 @@ import java.math.BigInteger
 import java.math.BigDecimal
 ----
 
+This is done because the classes from these packages are most commonly used. By importing these boilerplate code is reduced.
+
 === Simple import
 
 A simple import is an import statement where you fully define the class name along with the package. For example the import statement ++import groovy.xml.MarkupBuilder++ in the code below is a simple import which directly refers to a class inside a package.
@@ -81,14 +85,14 @@ include::{projectdir}/src/spec/test/PackageTest.groovy[tags=import_statement,ind
 
 === Star import
 
-Groovy, like Java, provides a special way to import all classes from a package using `*`, a so called Star import. `MarkupBuilder` is a class which is in package `groovy.xml`, alongside another class called `StreamingMarkupBuilder`. In case you need to use both classes, you can do:
+Groovy, like Java, provides a special way to import all classes from a package using `*`, the so called star import. `MarkupBuilder` is a class which is in package `groovy.xml`, alongside another class called `StreamingMarkupBuilder`. In case you need to use both classes, you can do:
 
 [source,groovy]
 ----
 include::{projectdir}/src/spec/test/PackageTest.groovy[tags=multiple_import,indent=0]
 ----
 
-That's perfectly valid code. But with a `*` import, we can achieve the same effect with just one line, where `*` imports all the classes under package `groovy.xml`:
+That's perfectly valid code. But with a `*` import, we can achieve the same effect with just one line. The star imports all the classes under package `groovy.xml`:
 
 [source,groovy]
 ----
@@ -203,7 +207,7 @@ include::{projectdir}/src/spec/test/ScriptsAndClassesSpecTest.groovy[tags=groovy
 <1> The `Main` class extends the `groovy.lang.Script` class
 <2> `groovy.lang.Script` requires a `run` method returning a value
 <3> the script body goes into the `run` method
-<4> the `main` method it automatically generated
+<4> the `main` method is automatically generated
 <5> and delegates the execution of the script on the `run` method
 
 If the script is in a file, then the base name of the file is used to determine the name of the generated script class.

--- a/src/spec/test/ScriptsAndClassesSpecTest.groovy
+++ b/src/spec/test/ScriptsAndClassesSpecTest.groovy
@@ -52,7 +52,7 @@ class ScriptsAndClassesSpecTest extends GroovyTestCase {
         assertScript '''
             // tag::method_in_script[]
             int fib(int n) {
-                n<2?1:fib(n-1)+fib(n-2)
+                n < 2 ? 1 : fib(n-1) + fib(n-2)
             }
             assert fib(10)==89
             // end::method_in_script[]


### PR DESCRIPTION
- Added why the packages are imported by defaults and also removed the 6 part as two classes are also imported.
- Changed the star import content as that was rendered as bold on the page.
- is instead of it

There are 2 other things that may need some clarification but I am not really sure
>dynamic than Java in that it allows you to define methods with the same name as an imported method as long as you have different types

This needs an example. I am not sure what this means so couldn't add.

>How can we fix it in one place, outside of the original class, without changing all the code that’s using it? Groovy has an elegant solution to this problem.

Is this example valid? I mean the imports will need to be changed. Correct?