### PR TITLE
Update GrapeIvy.groovy: set ivyInstance to IvyContext, for speed up

### DIFF
--- a/src/main/groovy/grape/GrapeIvy.groovy
+++ b/src/main/groovy/grape/GrapeIvy.groovy
@@ -109,6 +109,7 @@ class GrapeIvy implements GrapeEngine {
 
         settings.setVariable("ivy.default.configuration.m2compatible", "true")
         ivyInstance = Ivy.newInstance(settings)
+        org.apache.ivy.core.IvyContext.getContext().setIvy(ivyInstance);
         resolvedDependencies = []
         downloadedArtifacts = []
 


### PR DESCRIPTION
When custom grape.config is present(-Dgrape.config=...), there are no need load default ivysettings!

if you want see the diff,run with -Dgrape.config=... and -Divy.message.logger.level=4


![groovy-grape-custom-config-no-need-load-default-settings](https://cloud.githubusercontent.com/assets/1813709/8715158/4c9cfbe4-2bb0-11e5-85a8-41f1c9e237f2.png)


https://github.com/groovy/groovy-core/pull/665
