### PR TITLE
GROOVY-7518: hashCode() throws NPE when using @CompileStatic with @Eq…

### DIFF
--- a/src/main/org/codehaus/groovy/util/HashCodeHelper.java
+++ b/src/main/org/codehaus/groovy/util/HashCodeHelper.java
@@ -41,7 +41,15 @@ public class HashCodeHelper {
         return shift(current) + (int) var;
     }
 
+    public static int updateHash(int current, Character var) {
+        return shift(current) + (int) var;
+    }
+
     public static int updateHash(int current, int var) {
+        return shift(current) + var;
+    }
+
+    public static int updateHash(int current, Integer var) {
         return shift(current) + var;
     }
 
@@ -49,11 +57,23 @@ public class HashCodeHelper {
         return shift(current) + (int) (var ^ (var >>> 32));
     }
 
+    public static int updateHash(int current, Long var) {
+        return shift(current) + (int) (var ^ (var >>> 32));
+    }
+
     public static int updateHash(int current, float var) {
         return updateHash(current, Float.floatToIntBits(var));
     }
 
+    public static int updateHash(int current, Float var) {
+        return updateHash(current, Float.floatToIntBits(var));
+    }
+
     public static int updateHash(int current, double var) {
+        return updateHash(current, Double.doubleToLongBits(var));
+    }
+
+    public static int updateHash(int current, Double var) {
         return updateHash(current, Double.doubleToLongBits(var));
     }
 

--- a/src/test/org/codehaus/groovy/transform/CanonicalComponentsTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/CanonicalComponentsTransformTest.groovy
@@ -42,6 +42,24 @@ class CanonicalComponentsTransformTest extends GroovyShellTestCase {
         """
     }
 
+    void testHashCodeNullWrapperTypeCompileStatic_GROOVY7518() {
+        assertScript """
+            import groovy.transform.*
+
+            @EqualsAndHashCode
+            @CompileStatic
+            class Person {
+                Character someCharacter
+                Integer someInteger
+                Long someLong
+                Float someFloat
+                Double someDouble
+            }
+
+            assert new Person().hashCode()
+        """
+    }
+
     void testBooleanPropertyGROOVY6407() {
         assertScript """
             @groovy.transform.EqualsAndHashCode


### PR DESCRIPTION
…ualsAndHashCode