### PR TITLE
GROOVY-7551: groovy-all has a dependency on com.googlecode:openbeans …

### DIFF
--- a/gradle/upload.gradle
+++ b/gradle/upload.gradle
@@ -27,7 +27,7 @@ if (isUsingBintray) {
 def removeJarjaredDependencies = { p ->
     p.dependencies.removeAll(p.dependencies.findAll {
         it.groupId == 'org.codehaus.groovy' ||
-                (['asm', 'asm-util', 'asm-analysis', 'asm-tree', 'asm-commons', 'antlr', 'commons-cli'].contains(it.artifactId))
+                (['asm', 'asm-util', 'asm-analysis', 'asm-tree', 'asm-commons', 'antlr', 'commons-cli', 'openbeans'].contains(it.artifactId))
     })
 }
 


### PR DESCRIPTION
…that is not available on Maven Central