### PR TITLE
Completion fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -218,7 +218,7 @@ The following class within this product:
     org.codehaus.groovy.tools.shell.completion.FileNameCompleter
 
 was derived from JLine 2.12, and the following patch:
-https://github.com/jline/jline2/issues/90
+https://github.com/jline/jline2/pull/204
 JLine2 is made available under a BSD License.
 For details, see licenses/jline2-license.
 

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/CommandSupport.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/CommandSupport.groovy
@@ -23,6 +23,7 @@ import jline.console.completer.NullCompleter
 import jline.console.completer.StringsCompleter
 import jline.console.history.FileHistory
 import org.codehaus.groovy.tools.shell.completion.StricterArgumentCompleter
+import org.codehaus.groovy.tools.shell.completion.PatchedStringsCompleter
 import org.codehaus.groovy.tools.shell.util.Logger
 import org.codehaus.groovy.tools.shell.util.MessageSource
 
@@ -130,23 +131,27 @@ abstract class CommandSupport
         }
 
         List<Completer> list = new ArrayList<Completer>()
-        list << new StringsCompleter(name, shortcut)
-
         List<Completer> completers = createCompleters()
 
+        PatchedStringsCompleter stringCompleter = new PatchedStringsCompleter(name, shortcut)
+        if (!completers) {
+             stringCompleter.setWithBlank(false)
+        }
+        list << stringCompleter
+
         if (completers) {
+            // replace null/empty with NullCompleter
             completers.each {Completer it ->
                 if (it) {
                     list << it
-                }
-                else {
+                } else {
                     list << new NullCompleter()
                 }
             }
-        }
-        else {
+        } else {
             list << new NullCompleter()
         }
+
 
         return new StricterArgumentCompleter(list)
     }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/ComplexCommandSupport.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/ComplexCommandSupport.groovy
@@ -49,7 +49,7 @@ abstract class ComplexCommandSupport
     @Override
     protected List<Completer> createCompleters() {
         def c = new SimpleCompletor()
-
+        c.setWithBlank(false)
         functions.each { String it -> c.add(it) }
 
         return [ c, null ]

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/AliasCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/AliasCommand.groovy
@@ -41,7 +41,7 @@ class AliasCommand
     @Override
     protected List<Completer> createCompleters() {
         return [
-                new CommandNameCompleter(registry),
+                new CommandNameCompleter(registry, true),
                 null
         ]
     }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/DocCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/DocCommand.groovy
@@ -18,10 +18,7 @@
  */
 package org.codehaus.groovy.tools.shell.commands
 
-import jline.console.completer.AggregateCompleter
-import jline.console.completer.ArgumentCompleter
 import jline.console.completer.Completer
-import jline.console.completer.StringsCompleter
 
 import org.codehaus.groovy.tools.shell.CommandSupport
 import org.codehaus.groovy.tools.shell.Groovysh
@@ -112,9 +109,9 @@ class DocCommand extends CommandSupport {
         } else if (hasAWTDesktopPlatformSupport) {
             browseWithAWT(urls)
         } else {
-            fail "Browser could not be opened caused by missing platform support for 'java.awt.Desktop'. Please set " +
+            fail 'Browser could not be opened caused by missing platform support for 'java.awt.Desktop'. Please set ' +
                  "a $ENV_BROWSER_GROOVYSH or $ENV_BROWSER environment variable referring to the browser binary to " +
-                 "solve this issue."
+                 'solve this issue.'
         }
     }
 

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/DocCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/DocCommand.groovy
@@ -71,11 +71,9 @@ class DocCommand extends CommandSupport {
     }
 
     @Override
-    Completer getCompleter() {
-        return new AggregateCompleter([
-            new ArgumentCompleter([
-                new StringsCompleter(name, shortcut),
-                new ImportCompleter(shell.packageHelper, shell.interp, false)])])
+    protected List<Completer> createCompleters() {
+        return [new ImportCompleter(shell.packageHelper, shell.interp, false),
+                null]
     }
 
     @Override

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HelpCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HelpCommand.groovy
@@ -43,7 +43,7 @@ class HelpCommand
 
     protected List<Completer> createCompleters() {
         return [
-            new CommandNameCompleter(registry),
+            new CommandNameCompleter(registry, false),
             null
         ]
     }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HistoryCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HistoryCommand.groovy
@@ -47,8 +47,10 @@ class HistoryCommand
             return list
         }
 
+        SimpleCompletor subCommandsCompletor = new SimpleCompletor(loader)
+        subCommandsCompletor.setWithBlank(false)
         return [
-            new SimpleCompletor(loader),
+            subCommandsCompletor,
             null
         ]
     }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/InspectCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/InspectCommand.groovy
@@ -72,7 +72,7 @@ class InspectCommand
         }
 
         if (!subject) {
-            io.out.println('Subject is null; nothing to inspect') // TODO: i18n
+            io.out.println('Subject is null, false or empty; nothing to inspect') // TODO: i18n
         } else {
             // Only set LAF once.
             if (!lafInitialized) {
@@ -116,7 +116,7 @@ class InspectCommandCompletor
 
     InspectCommandCompletor(final Binding binding) {
         assert binding
-
+        this.setWithBlank(false)
         this.binding = binding
     }
 

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/LoadCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/LoadCommand.groovy
@@ -55,7 +55,7 @@ class LoadCommand
         for (source in args) {
             URL url
 
-            log.debug("Attempting to load: \"$url\"")
+            log.debug("Attempting to load: \"$source\"")
 
             try {
                 url = new URL("$source")

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/LoadCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/LoadCommand.groovy
@@ -41,7 +41,7 @@ class LoadCommand
 
     @Override
     protected List<Completer> createCompleters() {
-        return [ new FileNameCompleter(true, true) ]
+        return [ new FileNameCompleter(true) ]
     }
 
     @Override

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/CommandNameCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/CommandNameCompleter.groovy
@@ -30,9 +30,9 @@ import org.codehaus.groovy.tools.shell.util.SimpleCompletor
 class CommandNameCompleter extends SimpleCompletor {
     private final CommandRegistry registry
 
-    CommandNameCompleter(final CommandRegistry registry) {
+    CommandNameCompleter(final CommandRegistry registry, boolean withBlank) {
         assert registry
-
+        setWithBlank(withBlank)
         this.registry = registry
     }
 

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/FileNameCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/FileNameCompleter.groovy
@@ -66,9 +66,17 @@ implements Completer
 
     private static final boolean OS_IS_WINDOWS;
 
-    private final boolean blankSuffix = true;
+    private boolean printSpaceAfterFullCompletion = true;
 
-    private final handleLeadingHyphen = false;
+    private boolean handleLeadingHyphen = false;
+
+    public boolean getPrintSpaceAfterFullCompletion() {
+        return printSpaceAfterFullCompletion;
+    }
+
+    public void setPrintSpaceAfterFullCompletion(boolean printSpaceAfterFullCompletion) {
+        this.printSpaceAfterFullCompletion = printSpaceAfterFullCompletion;
+    }
 
     static {
         String os = Configuration.getOsName();
@@ -78,8 +86,8 @@ implements Completer
     public FileNameCompleter() {
     }
 
-    public FileNameCompleter(boolean blankSuffix) {
-        this.blankSuffix = blankSuffix;
+    public FileNameCompleter(boolean printSpaceAfterFullCompletion) {
+        this.printSpaceAfterFullCompletion = printSpaceAfterFullCompletion;
     }
 
 
@@ -136,19 +144,19 @@ implements Completer
         return matchFiles(buffer, translated, entries, candidates, hyphenChar);
     }
 
-    protected String separator() {
+    protected static String separator() {
         return File.separator;
     }
 
-    protected File getUserHome() {
+    protected static File getUserHome() {
         return Configuration.getUserHome();
     }
 
-    protected File getUserDir() {
+    protected static File getUserDir() {
         return new File(".");
     }
 
-    protected int matchFiles(final String buffer, final String translated, final File[] files, final List<CharSequence> candidates, hyphenChar) {
+    protected int matchFiles(final String buffer, final String translated, final File[] files, final List<CharSequence> candidates, final String hyphenChar) {
         if (files == null) {
             return -1;
         }
@@ -168,7 +176,7 @@ implements Completer
                     if (file.isDirectory()) {
                         name += separator();
                     } else {
-                        if (blankSuffix && !hyphenChar) {
+                        if (printSpaceAfterFullCompletion && !hyphenChar) {
                             name += ' ';
                         }
                     }
@@ -192,8 +200,8 @@ implements Completer
         return name;
     }
 
-    private String escapedNameInHyphens(String name, String hyphen) {
+    private String escapedNameInHyphens(final CharSequence name, String hyphen) {
         // need to escape every instance of chartoEscape, and every instance of the escape char backslash
-        return hyphen + name.replace('\\', '\\\\').replace(hyphen, '\\' + hyphen) + hyphen
+        return hyphen + name.toString().replace('\\', '\\\\').replace(hyphen, '\\' + hyphen) + hyphen
     }
 }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/FileNameCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/FileNameCompleter.groovy
@@ -115,14 +115,15 @@ implements Completer
             translated = translated.substring(1);
         }
 
-        File homeDir = getUserHome();
-
-        // Special character: ~ maps to the user's home directory
-        if (translated.startsWith("~" + separator())) {
-            translated = homeDir.getPath() + translated.substring(1);
-        }
-        else if (translated.startsWith("~")) {
-            translated = homeDir.getParentFile().getAbsolutePath();
+        // Special character: ~ maps to the user's home directory in most OSs
+        if (!OS_IS_WINDOWS && translated.startsWith("~")) {
+            File homeDir = getUserHome();
+            if (translated.startsWith("~" + separator())) {
+                translated = homeDir.getPath() + translated.substring(1);
+            }
+            else {
+                translated = homeDir.getParentFile().getAbsolutePath();
+            }
         }
         else if (!(new File(translated).isAbsolute())) {
             String cwd = getUserDir().getAbsolutePath();

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/PatchedStringsCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/PatchedStringsCompleter.groovy
@@ -1,6 +1,5 @@
 package org.codehaus.groovy.tools.shell.completion
 
-import jline.console.completer.Completer
 import jline.console.completer.StringsCompleter
 
 import static jline.internal.Preconditions.checkNotNull

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/PatchedStringsCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/PatchedStringsCompleter.groovy
@@ -1,0 +1,52 @@
+package org.codehaus.groovy.tools.shell.completion
+
+import jline.console.completer.Completer
+import jline.console.completer.StringsCompleter
+
+import static jline.internal.Preconditions.checkNotNull
+
+/**
+ * Changes JLine 2.12 StringsCompleter behavior to either always or never add blanks.
+ */
+public class PatchedStringsCompleter
+        extends StringsCompleter
+{
+
+    private boolean withBlank = true
+
+    public PatchedStringsCompleter() {
+    }
+
+    public PatchedStringsCompleter(final Collection<String> strings) {
+        super(strings)
+    }
+
+    public PatchedStringsCompleter(final String... strings) {
+        this(Arrays.asList(strings));
+    }
+
+    void setWithBlank(boolean withBlank) {
+        this.withBlank = withBlank
+    }
+
+    @Override
+    public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
+        // buffer could be null
+        checkNotNull(candidates);
+
+        if (buffer == null) {
+            candidates.addAll(strings.collect({it -> withBlank ? it + ' ' : it}));
+        }
+        else {
+            for (String match : strings.tailSet(buffer)) {
+                if (!match.startsWith(buffer)) {
+                    break;
+                }
+
+                candidates.add(withBlank ? match + ' ' : match);
+            }
+        }
+
+        return candidates.isEmpty() ? -1 : 0;
+    }
+}

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/StricterArgumentCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/StricterArgumentCompleter.groovy
@@ -23,15 +23,14 @@ import jline.console.completer.ArgumentCompleter
 import jline.console.completer.ArgumentCompleter.ArgumentDelimiter
 import jline.console.completer.ArgumentCompleter.ArgumentList
 import jline.console.completer.Completer
+import jline.internal.Log
 
 import static jline.internal.Preconditions.checkNotNull;
 
 /**
- * Similar to a strict jline ArgumentCompleter, this completer
- * completes the n+1th argument only if the 1st to nth argument have matches.
- * However, it only does so if the 1st to nth argument match *exactly*, not just partially.
- * This prevents interaction of completers between e.g. ":s", ":set" ":show" on same ":s foo"
+ * This fixes strict jline 2.12 ArgumentCompleter
  * See https://github.com/jline/jline2/pull/123
+ * See https://github.com/jline/jline2/pull/202
  *
  */
 @CompileStatic
@@ -48,40 +47,91 @@ class StricterArgumentCompleter extends ArgumentCompleter {
     }
 
     public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
-        if (isStrict()) {
-            checkNotNull(candidates);
-            ArgumentDelimiter delim = getDelimiter();
-            ArgumentList list = delim.delimit(buffer, cursor);
-            int argIndex = list.getCursorArgumentIndex();
-            // stricter check that all previous arguments have been matched *exactly*
-            // ensure that all the previous completers are successful before allowing this completer to pass (only if strict).
-            for (int i = 0; i < argIndex; i++) {
-                Completer sub = completers.get(i >= completers.size() ? (completers.size() - 1) : i);
-                String[] args = list.getArguments();
-                String arg = (args == null || i >= args.length) ? "" : args[i];
+        // buffer can be null
+        checkNotNull(candidates);
 
-                List<CharSequence> subCandidates = new LinkedList<CharSequence>();
+        ArgumentDelimiter delim = getDelimiter();
+        ArgumentList list = delim.delimit(buffer, cursor);
+        int argpos = list.getArgumentPosition();
+        int argIndex = list.getCursorArgumentIndex();
 
-                if (sub.complete(arg, arg.length(), subCandidates) == -1) {
-                    return -1;
-                }
+        if (argIndex < 0) {
+            return -1;
+        }
 
-                boolean candidateMatches = false;
-                for (CharSequence subCandidate: subCandidates) {
-                    // Since we know delimiter is whitespace, we can use String.trim(), in contrast to super class
-                    String trimmedCand = subCandidate.toString().trim();
-                    if (trimmedCand.equals(arg)) {
-                        candidateMatches = true;
-                        break;
-                    }
-                }
-                if (!candidateMatches) {
-                    return -1;
-                }
+        List<Completer> completers = getCompleters();
+        Completer completer;
 
+        // if we are beyond the end of the completers, just use the last one
+        if (argIndex >= completers.size()) {
+            completer = completers.get(completers.size() - 1);
+        }
+        else {
+            completer = completers.get(argIndex);
+        }
+
+        // ensure that all the previous completers are successful before allowing this completer to pass (only if strict).
+        for (int i = 0; isStrict() && (i < argIndex); i++) {
+            Completer sub = completers.get(i >= completers.size() ? (completers.size() - 1) : i);
+            String[] args = list.getArguments();
+            String arg = (args == null || i >= args.length) ? "" : args[i];
+
+            List<CharSequence> subCandidates = new LinkedList<CharSequence>();
+            int offset = sub.complete(arg, arg.length(), subCandidates);
+            if (offset == -1) {
+                return -1;
             }
 
+            // for strict matching, one of the candidates must equal the current argument "arg",
+            // starting from offset within arg, but the suitable candidate may actually also have a
+            // delimiter at then end.
+            boolean candidateMatches = false;
+            for (CharSequence subCandidate: subCandidates) {
+                // each SUbcandidate may end with the delimiter.
+                // That it contains the delimiter is possible, but not plausible.
+                String[] candidateDelimList = delim.delimit(subCandidate, 0).getArguments();
+                if (candidateDelimList.length == 0) {
+                    continue;
+                }
+                String trimmedCand = candidateDelimList[0];
+                if (trimmedCand.equals(arg.substring(offset))) {
+                    candidateMatches = true;
+                    break;
+                }
+            }
+            if (!candidateMatches) {
+                return -1;
+            }
         }
-        return super.complete(buffer, cursor, candidates);
+
+        int ret = completer.complete(list.getCursorArgument(), argpos, candidates);
+
+        if (ret == -1) {
+            return -1;
+        }
+
+        int pos = ret + list.getBufferPosition() - argpos;
+
+        // Special case: when completing in the middle of a line, and the area under the cursor is a delimiter,
+        // then trim any delimiters from the candidates, since we do not need to have an extra delimiter.
+        //
+        // E.g., if we have a completion for "foo", and we enter "f bar" into the buffer, and move to after the "f"
+        // and hit TAB, we want "foo bar" instead of "foo  bar".
+
+        if ((cursor != buffer.length()) && delim.isDelimiter(buffer, cursor)) {
+            for (int i = 0; i < candidates.size(); i++) {
+                CharSequence val = candidates.get(i);
+
+                while (val.length() > 0 && delim.isDelimiter(val, val.length() - 1)) {
+                    val = val.subSequence(0, val.length() - 1);
+                }
+
+                candidates.set(i, val);
+            }
+        }
+
+        Log.trace("Completing ", buffer, " (pos=", cursor, ") with: ", candidates, ": offset=", pos);
+
+        return pos;
     }
 }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/CommandArgumentParser.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/CommandArgumentParser.groovy
@@ -25,7 +25,7 @@ class CommandArgumentParser {
 
     /**
      * takes a String and tokenizes it according to posix-shell-like rules, meaning
-     * arguments are separated by blanks or hyphens, and hyphens wrap tokens regardless
+     * arguments are separated by non-escaped blanks or hyphens, and hyphens wrap tokens regardless
      * of blanks, other hyphens or escaped hyphens within the wrapping hyphens.
      *
      * Example: "foo bar 123'456' 'abc\'def\\' ''"  has 6 tokens:
@@ -50,12 +50,25 @@ class CommandArgumentParser {
                 break
             }
             String ch = line.charAt(index)
-            // escaped char?
-            if (ch == '\\' && (singleHyphenOpen || doubleHyphenOpen)) {
-                ch = (index == line.length() - 1) ? '\\' : line.charAt(index + 1)
-                index++
-                currentToken += ch
-                continue
+            // escaped char? -> maybe unescape
+            if (ch == '\\') {
+                if (index >= line.length() - 1) {
+                    // end reached
+                    currentToken += ch
+                    continue
+                }
+                if (singleHyphenOpen || doubleHyphenOpen) {
+                    // add escaped, no other parsing action
+                    currentToken += ch
+                    index++
+                    currentToken += line.charAt(index)
+                    continue
+                } else {
+                    // unescape, only add char after, no parsing action
+                    index++
+                    currentToken += line.charAt(index)
+                    continue
+                }
             }
 
             if (ch == '"' && !singleHyphenOpen) {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/SimpleCompletor.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/SimpleCompletor.groovy
@@ -33,7 +33,9 @@ class SimpleCompletor implements Completer {
     /**
     * A delimiter to use to qualify completions.
     */
-    String delimiter
+    protected String delimiter
+
+    boolean withBlank = true
 
 
     SimpleCompletor(final String[] candidates) {
@@ -72,6 +74,10 @@ class SimpleCompletor implements Completer {
         }
     }
 
+    void setWithBlank(boolean withBlank) {
+        this.withBlank = withBlank
+    }
+
     void add(final String candidate) {
         addCandidateString(candidate)
     }
@@ -82,9 +88,6 @@ class SimpleCompletor implements Completer {
         return null
     }
 
-    //
-    // NOTE: Duplicated (and augmented) from JLine sources to make it call getCandidates() to make the list more dynamic
-    //
     @Override
     int complete(final String buffer, final int cursor, final List<CharSequence> clist) {
         String start = (buffer == null) ? '' : buffer
@@ -108,11 +111,11 @@ class SimpleCompletor implements Completer {
                 }
             }
 
-            clist.add(can)
-        }
+            if (withBlank) {
+                can += ' '
+            }
 
-        if (clist.size() == 1) {
-            clist.set(0, ((String) clist.get(0)) + ' ')
+            clist.add(can)
         }
 
         // the index of the completion is always from the beginning of the buffer.

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/AllCompletorsTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/AllCompletorsTest.groovy
@@ -105,18 +105,18 @@ class AllCompletorsTest extends GroovyTestCase {
 
     void testEmpty() {
         def result = complete('', 0)
-        assert HelpCommand.COMMAND_NAME in result[0]
+        assert HelpCommand.COMMAND_NAME + ' ' in result[0]
         assert ExitCommand.COMMAND_NAME in result[0]
-        assert 'import' in result[0]
-        assert ShowCommand.COMMAND_NAME in result[0]
-        assert SetCommand.COMMAND_NAME in result[0]
-        assert InspectCommand.COMMAND_NAME in result[0]
-        assert DocCommand.COMMAND_NAME in result[0]
+        assert 'import ' in result[0]
+        assert ShowCommand.COMMAND_NAME + ' ' in result[0]
+        assert SetCommand.COMMAND_NAME + ' ' in result[0]
+        assert InspectCommand.COMMAND_NAME + ' ' in result[0]
+        assert DocCommand.COMMAND_NAME + ' ' in result[0]
         assert 0 == result[1]
     }
 
     void testExitEdit() {
-        assert [["${ExitCommand.COMMAND_NAME} ", ':e', EditCommand.COMMAND_NAME], 0] == complete(':e', 0)
+        assert [[ExitCommand.COMMAND_NAME, ':e', EditCommand.COMMAND_NAME], 0] == complete(':e', 0)
     }
 
     void testShow() {
@@ -126,7 +126,7 @@ class AllCompletorsTest extends GroovyTestCase {
 
     void testShowV() {
         String prompt = ShowCommand.COMMAND_NAME + ' v'
-        assert [['variables '], prompt.length() - 1] == complete(prompt, prompt.length())
+        assert [['variables'], prompt.length() - 1] == complete(prompt, prompt.length())
     }
 
     void testShowVariables() {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/CommandCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/CommandCompletorTest.groovy
@@ -45,10 +45,10 @@ extends CompletorTestSupport {
             completor.refresh()
 
             assert 0 == completor.complete(':a', ':a'.length(), candidates)
-            assert [':a', AliasCommand.COMMAND_NAME] == candidates
+            assert [':a ', AliasCommand.COMMAND_NAME + ' '] == candidates
             candidates = []
             assert 3 == completor.complete(':a ', ':a '.length(), candidates)
-            assert [':=', ':S', SetCommand.COMMAND_NAME, ShowCommand.COMMAND_NAME] == candidates
+            assert [':= ', ':S ', SetCommand.COMMAND_NAME + ' ', ShowCommand.COMMAND_NAME + ' '] == candidates
         }
     }
 
@@ -70,15 +70,15 @@ extends CompletorTestSupport {
             candidates = []
             assert 5 == completor.complete(buffer, buffer.length(), candidates)
         }
-        assert Groovysh.AUTOINDENT_PREFERENCE_KEY in candidates
-        assert Groovysh.COLORS_PREFERENCE_KEY in candidates
-        assert Groovysh.METACLASS_COMPLETION_PREFIX_LENGTH_PREFERENCE_KEY in candidates
-        assert Preferences.EDITOR_KEY in candidates
-        assert Preferences.PARSER_FLAVOR_KEY in candidates
-        assert Preferences.VERBOSITY_KEY in candidates
-        assert Preferences.SANITIZE_STACK_TRACE_KEY in candidates
-        assert Preferences.SHOW_LAST_RESULT_KEY in candidates
-        assert Preferences.VERBOSITY_KEY in candidates
+        assert Groovysh.AUTOINDENT_PREFERENCE_KEY + ' ' in candidates
+        assert Groovysh.COLORS_PREFERENCE_KEY + ' ' in candidates
+        assert Groovysh.METACLASS_COMPLETION_PREFIX_LENGTH_PREFERENCE_KEY + ' ' in candidates
+        assert Preferences.EDITOR_KEY + ' ' in candidates
+        assert Preferences.PARSER_FLAVOR_KEY + ' ' in candidates
+        assert Preferences.VERBOSITY_KEY + ' ' in candidates
+        assert Preferences.SANITIZE_STACK_TRACE_KEY + ' ' in candidates
+        assert Preferences.SHOW_LAST_RESULT_KEY + ' ' in candidates
+        assert Preferences.VERBOSITY_KEY + ' ' in candidates
     }
 
     void testSave() {
@@ -90,7 +90,7 @@ extends CompletorTestSupport {
             completor.refresh()
 
             assert 0 == completor.complete(':s', ':s'.length(), candidates)
-            assert [':s', SaveCommand.COMMAND_NAME] == candidates
+            assert [':s ', SaveCommand.COMMAND_NAME + ' '] == candidates
             candidates = []
             String buffer = SaveCommand.COMMAND_NAME + ' '
             assert 6 == completor.complete(buffer, buffer.length(), candidates)
@@ -132,7 +132,7 @@ extends CompletorTestSupport {
             completor.refresh()
 
             assert 0 == completor.complete(':s', ':s'.length(), candidates)
-            assert [':s', SaveCommand.COMMAND_NAME, SetCommand.COMMAND_NAME + ' ', ShowCommand.COMMAND_NAME + ' '] == candidates
+            assert [':s ', SaveCommand.COMMAND_NAME + ' ', SetCommand.COMMAND_NAME + ' ', ShowCommand.COMMAND_NAME + ' '] == candidates
             candidates = []
             String buffer = SaveCommand.COMMAND_NAME + ' '
             assert 6 == completor.complete(buffer, buffer.length(), candidates)

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ImportCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ImportCompletorTest.groovy
@@ -17,14 +17,15 @@
  *  under the License.
  */
 package org.codehaus.groovy.tools.shell
-
 import groovy.mock.interceptor.MockFor
+import jline.console.completer.ArgumentCompleter
 import jline.console.completer.Completer
+import jline.console.completer.NullCompleter
+import jline.console.completer.StringsCompleter
 import org.codehaus.groovy.tools.shell.commands.ImportCommand
 import org.codehaus.groovy.tools.shell.commands.ImportCompleter
 import org.codehaus.groovy.tools.shell.util.PackageHelper
 import org.codehaus.groovy.tools.shell.util.Preferences
-
 /**
  * as opposed to MockFor, traditional custom mocking allows @CompileStatic for the class under Test
  */
@@ -287,7 +288,7 @@ class ImportCompleterTest extends CompletorTestSupport {
             def candidates = []
             assert 0 == completer.complete('', 0, candidates)
             // order changed by sort
-            assert [':i', ':i', 'import', 'import'] == candidates.sort()
+            assert [':i ', ':i ', 'import ', 'import '] == candidates.sort()
         }
     }
 
@@ -332,7 +333,7 @@ class ImportCompleterTest extends CompletorTestSupport {
             def candidates = []
             // argument completer completes after 'import '
             String buffer = 'import java.'
-            assert 12 == completer.complete(buffer, buffer.length(), candidates)
+            assert buffer.length() == completer.complete(buffer, buffer.length(), candidates)
             // order changed by sort, needed to run tests on different JDKs
             assert ['* ', 'java.', 'test.'] == candidates.sort()
         }
@@ -349,14 +350,14 @@ class ImportCompleterTest extends CompletorTestSupport {
             def candidates = []
             // argument completer completes after 'import '
             String buffer = 'import java.lang.'
-            assert 17 == completer.complete(buffer, buffer.length(), candidates)
+            assert buffer.length() == completer.complete(buffer, buffer.length(), candidates)
             // order changed by sort, needed to make tests run on different JDks
             assert ['* ', 'java.', 'test.'] == candidates.sort()
         }
     }
 
     void testAs() {
-        mockPackageHelper = new MockPackageHelper(['java', 'test'])
+        mockPackageHelper = new MockPackageHelper(['java', 'Test'])
         groovyshMocker.demand.getPackageHelper(1) { mockPackageHelper }
         groovyshMocker.demand.getInterp(1) {}
         groovyshMocker.use {
@@ -365,8 +366,8 @@ class ImportCompleterTest extends CompletorTestSupport {
             Completer completer = iCom.completer
             def candidates = []
             // mock package
-            String buffer = 'import java.test '
-            assert 17 == completer.complete(buffer, buffer.length(), candidates)
+            String buffer = 'import java.Test '
+            assert buffer.length() == completer.complete(buffer, buffer.length(), candidates)
             assert ['as '] == candidates
         }
     }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/SetCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/SetCommandTest.groovy
@@ -18,10 +18,10 @@
  */
 package org.codehaus.groovy.tools.shell.commands
 
+import jline.console.completer.Completer
 import org.codehaus.groovy.tools.shell.Groovysh
 import org.codehaus.groovy.tools.shell.util.PackageHelper
 import org.codehaus.groovy.tools.shell.util.Preferences
-import org.codehaus.groovy.tools.shell.util.SimpleCompletor
 
 /**
  * Tests for the {@link SetCommand} class.
@@ -39,15 +39,15 @@ class SetCommandTest
 
         List<String> candidates = []
         SetCommand command = new SetCommand(shell)
-        ArrayList<SimpleCompletor> completors = command.createCompleters()
+        List<Completer> completors = command.createCompleters()
         assert 2 == completors.size()
         assert 0 == completors[0].complete('', 0, candidates)
-        assert Groovysh.AUTOINDENT_PREFERENCE_KEY in candidates
-        assert PackageHelper.IMPORT_COMPLETION_PREFERENCE_KEY in candidates
-        assert Preferences.EDITOR_KEY in candidates
-        assert Preferences.PARSER_FLAVOR_KEY in candidates
-        assert Preferences.SANITIZE_STACK_TRACE_KEY in candidates
-        assert Preferences.SHOW_LAST_RESULT_KEY in candidates
-        assert Preferences.VERBOSITY_KEY in candidates
+        assert Groovysh.AUTOINDENT_PREFERENCE_KEY + ' ' in candidates
+        assert PackageHelper.IMPORT_COMPLETION_PREFERENCE_KEY + ' ' in candidates
+        assert Preferences.EDITOR_KEY + ' ' in candidates
+        assert Preferences.PARSER_FLAVOR_KEY + ' ' in candidates
+        assert Preferences.SANITIZE_STACK_TRACE_KEY + ' ' in candidates
+        assert Preferences.SHOW_LAST_RESULT_KEY + ' ' in candidates
+        assert Preferences.VERBOSITY_KEY + ' ' in candidates
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/util/CommandArgumentParserTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/util/CommandArgumentParserTest.groovy
@@ -28,6 +28,9 @@ class CommandArgumentParserTest extends GroovyTestCase {
         // blanks
         assert ['foo', 'bar'] == CommandArgumentParser.parseLine('  foo bar  ')
 
+        // escaped blanks
+        assert ['foo bar'] == CommandArgumentParser.parseLine('foo\\ bar')
+
         // empties
         assert ['', '', '', ''] == CommandArgumentParser.parseLine('\'\'\'\' \'\'  \'\'')
         assert ['', '', '', ''] == CommandArgumentParser.parseLine('"""" ""  ""')
@@ -36,8 +39,13 @@ class CommandArgumentParserTest extends GroovyTestCase {
         assert ['foo bar', 'baz bam'] == CommandArgumentParser.parseLine(' \'foo bar\' \'baz bam\'')
         assert ['foo bar', 'baz bam'] == CommandArgumentParser.parseLine(' "foo bar" "baz bam"')
 
-        // escaped hyphens and escape signs
-        assert ['foo \\ "\' bar'] == CommandArgumentParser.parseLine('\'foo \\\\ "\\\' bar\'')
+        // escaped hyphens and escape signs within hyphens
+        // intentionally adding list on left hand side because power asserts become confusing with escaping
+        assert [] + ['foo \\\\ "\\\' bar'] == CommandArgumentParser.parseLine('\'foo \\\\ "\\\' bar\'')
+
+        // escaped hyphens and escape signs outside hyphens
+        assert [] + ['foo', '\\', '"', '\'', 'bar'] == CommandArgumentParser.parseLine('foo \\\\ \\" \\\' bar')
+
         // no space between hyphentokens
         assert ['bar', 'foo', 'bam', 'baz'] == CommandArgumentParser.parseLine('bar"foo"\'bam\'\'baz\'')
 


### PR DESCRIPTION
This PR contains multiple minor fixes for tab completion in groovysh. I detected those while working on upgrading to jline 2.13. The main fix is for completion of files or folders with blanks or hyphens in the name. The previous implementation tried to juggle with opening and closing hyphens, but this caused several bugs.

Aside from this, I changed a bit the handling of blanks, such that completion of a command without arguments (like ```:exit```) is not completed with a blank at the end, suggesting more arguments are expected/allowed.