### PR TITLE
Groovysh: Fix imports not working at all in interpreter mode

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -245,7 +245,7 @@ class Groovysh extends Shell {
         String variableBlocks = null
         // To make groovysh behave more like an interpreter, we need to retrieve all bound
         // vars at the end of script execution, and then update them into the groovysh Binding context.
-        Set<String> boundVars = ScriptVariableAnalyzer.getBoundVars(importsSpec + Parser.NEWLINE + current.join(Parser.NEWLINE))
+        Set<String> boundVars = ScriptVariableAnalyzer.getBoundVars(importsSpec + Parser.NEWLINE + current.join(Parser.NEWLINE), interp.classLoader)
         if (boundVars) {
             variableBlocks = "$COLLECTED_BOUND_VARS_MAP_VARNAME = new HashMap();"
             boundVars.each({ String varname ->

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzer.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzer.groovy
@@ -89,7 +89,8 @@ class ScriptVariableAnalyzer {
     static class VisitorClassLoader extends GroovyClassLoader {
         final GroovyClassVisitor visitor
 
-        VisitorClassLoader(final GroovyClassVisitor visitor) {
+        VisitorClassLoader(final GroovyClassVisitor visitor, ClassLoader parent) {
+            super(parent == null ?  Thread.currentThread().getContextClassLoader() : parent)
             this.visitor = visitor
         }
 
@@ -101,10 +102,10 @@ class ScriptVariableAnalyzer {
         }
     }
 
-    static Set<String> getBoundVars(final String scriptText) {
+    static Set<String> getBoundVars(final String scriptText, ClassLoader parent) {
         assert scriptText != null
         GroovyClassVisitor visitor = new VariableVisitor()
-        VisitorClassLoader myCL = new VisitorClassLoader(visitor)
+        VisitorClassLoader myCL = new VisitorClassLoader(visitor, parent)
         // simply by parsing the script with our classloader
         // our visitor will be called and will visit all the variables
         myCL.parseClass(scriptText)

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -39,6 +39,7 @@ class GroovyshTest extends GroovyTestCase {
         mockErr = new ByteArrayOutputStream()
         testio = new IO(new ByteArrayInputStream(), mockOut, mockErr)
         testio.setVerbosity(IO.Verbosity.INFO)
+        Preferences.put(Groovysh.INTERPRETER_MODE_PREFERENCE_KEY, 'false')
     }
 
     void testCompleteExpr() {
@@ -267,6 +268,17 @@ class GroovyshTest extends GroovyTestCase {
         } catch (ArithmeticException e) {}
     }
 
+    void testImports() {
+        Groovysh groovysh = new Groovysh(testio)
+        groovysh.execute('import java.rmi.Remote ')
+        assert mockOut.toString().length() > 0
+        assert 'java.rmi.Remote\n' == mockOut.toString().normalize()[-('java.rmi.Remote\n'.length())..-1]
+        groovysh.execute('Remote r')
+        assert mockOut.toString().length() > 0
+        // mostly assert no exception
+        assert 'null\n' == mockOut.toString().normalize()[-5..-1]
+    }
+
     static File createTemporaryGroovyScriptFile(content) {
         String testName = 'GroovyshTest' + System.currentTimeMillis()
         File groovyCode = new File(System.getProperty('java.io.tmpdir'), testName)
@@ -295,8 +307,6 @@ class GroovyshInterpreterModeTest extends GroovyshTest {
 
     void testBoundVar() {
         Groovysh groovysh = new Groovysh(testio)
-        // default is false
-
         groovysh.execute('int x = 3')
         assert mockOut.toString().length() > 0
         assert ' 3\n' == mockOut.toString().normalize()[-3..-1]
@@ -307,8 +317,6 @@ class GroovyshInterpreterModeTest extends GroovyshTest {
 
     void testBoundVarmultiple() {
         Groovysh groovysh = new Groovysh(testio)
-        // default is false
-        Preferences.put(Groovysh.INTERPRETER_MODE_PREFERENCE_KEY, 'true')
         groovysh.execute('int x, y, z')
         assert mockOut.toString().length() > 0
         assert ' 0\n' == mockOut.toString().normalize()[-3..-1]

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -51,10 +51,15 @@ class GroovyshTest extends GroovyTestCase {
 
     void testClassDef() {
         Groovysh groovysh = new Groovysh(testio)
-        groovysh.execute('class Foo {}')
+        groovysh.execute('class MyFooTestClass{ String foo }')
         assert mockOut.toString().length() > 0
         assert ' true\n' == mockOut.toString().normalize()[-6..-1]
+        groovysh.execute('m = new MyFooTestClass()')
+        assert mockOut.toString().length() > 0
+        // mostly assert no exception
+        assert mockOut.toString().normalize().contains('MyFooTestClass@')
     }
+
 
     void testmethodDef() {
         Groovysh groovysh = new Groovysh(testio)

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzerTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzerTest.groovy
@@ -25,7 +25,11 @@ package org.codehaus.groovy.tools.shell.util
 class ScriptVariableAnalyzerTest extends GroovyTestCase {
 
     void testEmptyScript() {
-        assert [] as Set == ScriptVariableAnalyzer.getBoundVars('')
+        assert [] as Set == ScriptVariableAnalyzer.getBoundVars('', Thread.currentThread().contextClassLoader)
+    }
+
+    void testEmptyScriptNullLOader() {
+        assert [] as Set == ScriptVariableAnalyzer.getBoundVars('', null)
     }
 
     void testBound() {
@@ -33,7 +37,7 @@ class ScriptVariableAnalyzerTest extends GroovyTestCase {
    int a = 6
    String b = "7"
 '''
-        assert ['a', 'b'] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText)
+        assert ['a', 'b'] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText, Thread.currentThread().contextClassLoader)
     }
 
     void testUnBound() {
@@ -41,7 +45,7 @@ class ScriptVariableAnalyzerTest extends GroovyTestCase {
    a = 6
    b = "7"
 '''
-        assert [] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText)
+        assert [] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText, Thread.currentThread().contextClassLoader)
     }
 
     void testMixed() {
@@ -58,6 +62,6 @@ class ScriptVariableAnalyzerTest extends GroovyTestCase {
    }
    assert b
 '''
-        assert ['b', 'c'] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText)
+        assert ['b', 'c'] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText, Thread.currentThread().contextClassLoader)
     }
 }


### PR DESCRIPTION
Hi,

this is a bit embarassing. The interpreter mode introduced with Groovy 2.4 does not handle imports correctly. With the bug, it becomes impossible to import anything, as long as the shell is in interpreter mode. The fix is simple, since the interpreter mode merely missed to used the 'import' keyword, that I had stripped away for brevity from the list of imports.

I added a test which breaks if imports fail.