### PR TITLE
GROOVY-7519: Fixes JsonOuput.toJson() leads to StackOverflowException

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonOutput.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonOutput.java
@@ -287,7 +287,7 @@ public class JsonOutput {
                 writeArray(objectClass, object, buffer);
             } else if (Enum.class.isAssignableFrom(objectClass)) {
                 buffer.addQuoted(((Enum<?>) object).name());
-            }else if (objectClass == File.class){
+            }else if (File.class.isAssignableFrom(objectClass)){
                 Map<?, ?> properties = DefaultGroovyMethods.getProperties(object);
                 properties.remove("class");
                 properties.remove("declaringClass");

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonOutput.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonOutput.java
@@ -24,6 +24,7 @@ import groovy.lang.Closure;
 import groovy.util.Expando;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
+import java.io.File;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -286,6 +287,21 @@ public class JsonOutput {
                 writeArray(objectClass, object, buffer);
             } else if (Enum.class.isAssignableFrom(objectClass)) {
                 buffer.addQuoted(((Enum<?>) object).name());
+            }else if (objectClass == File.class){
+                Map<?, ?> properties = DefaultGroovyMethods.getProperties(object);
+                properties.remove("class");
+                properties.remove("declaringClass");
+                properties.remove("metaClass");
+                //Clean up all recursive references to File objects
+                Iterator<? extends Map.Entry<?, ?>> iterator = properties.entrySet().iterator();
+                while(iterator.hasNext()){
+                    Map.Entry<?,?> entry = iterator.next();
+                    if(entry.getValue() instanceof File){
+                        iterator.remove();
+                    }
+                }
+
+                writeMap(properties, buffer);
             } else {
                 Map<?, ?> properties = DefaultGroovyMethods.getProperties(object);
                 properties.remove("class");

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -415,6 +415,20 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson({'\1' 0}) == '{"\\u0001":0}'
         assert toJson({'\u0002' 0}) == '{"\\u0002":0}'
     }
+
+    void testFile() {
+        def file  = File.createTempFile('test', 'file-json')
+        def unusedProp = ['class', 'metaclass', 'declaringClass', 'canonicalFile', 'absoluteFile', 'parentFile']
+        def removeUnused = { map -> unusedProp.each { map.remove(it)}; map }
+
+        assert toJson(file) == toJson(removeUnused(file.properties))
+        def dir = File.createTempDir()
+        assert toJson(dir) == toJson(removeUnused(dir.properties))
+
+        def objectWithFile = new JsonEmbeddedFile(name: 'testFile', file: file)
+        assert toJson(objectWithFile) == "{\"file\":${toJson(file)},\"name\":\"testFile\"}".toString()
+    }
+
 }
 
 @Canonical
@@ -447,4 +461,9 @@ class JsonFoo {
 
 enum JsonStreetKind {
     street, boulevard, avenue
+}
+
+class JsonEmbeddedFile {
+    String name
+    File file
 }


### PR DESCRIPTION
JsonOutput overflows when serializing a File due to recursive references to File objects. Namely getAbsoluteFile(), getCanonicalFile(), and getParentFile(). These properties will be properly serialized by their counterpart methods getAbsolutePath(), getCanonicalPath() and getParent().