### PR TITLE
GROOVY-5763: Make InvokerHelper output self-consistent

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -62,6 +62,9 @@ public class InvokerHelper {
     protected static final Object[] EMPTY_ARGUMENTS = EMPTY_ARGS;
     protected static final Class[] EMPTY_TYPES = {};
 
+    // heuristic size to pre-alocate stringbuffers for collections of items
+    private static final int ITEM_ALLOCATE_SIZE = 5;
+
     public static final MetaClassRegistry metaRegistry = GroovySystem.getMetaClassRegistry();
 
     public static void removeClass(Class clazz) {
@@ -639,7 +642,8 @@ public class InvokerHelper {
         if (map.isEmpty()) {
             return "[:]";
         }
-        StringBuilder buffer = new StringBuilder("[");
+        StringBuilder buffer = new StringBuilder(ITEM_ALLOCATE_SIZE * map.size() * 2);
+        buffer.append('[');
         boolean first = true;
         for (Object o : map.entrySet()) {
             if (first) {
@@ -660,7 +664,7 @@ public class InvokerHelper {
                 buffer.append(format(entry.getValue(), verbose, sizeLeft(maxSize, buffer)));
             }
         }
-        buffer.append("]");
+        buffer.append(']');
         return buffer.toString();
     }
 
@@ -673,7 +677,8 @@ public class InvokerHelper {
     }
 
     private static String formatList(Collection collection, boolean verbose, int maxSize, boolean safe) {
-        StringBuilder buffer = new StringBuilder("[");
+        StringBuilder buffer = new StringBuilder(ITEM_ALLOCATE_SIZE * collection.size());
+        buffer.append('[');
         boolean first = true;
         for (Object item : collection) {
             if (first) {
@@ -704,7 +709,7 @@ public class InvokerHelper {
                 buffer.append(str);
             }
         }
-        buffer.append("]");
+        buffer.append(']');
         return buffer.toString();
     }
 
@@ -793,16 +798,15 @@ public class InvokerHelper {
         if (arguments == null) {
             return "null";
         }
-        String sbdry = "[";
-        String ebdry = "]";
-        StringBuilder argBuf = new StringBuilder(sbdry);
+        StringBuilder argBuf = new StringBuilder(arguments.length);
+        argBuf.append('[');
         for (int i = 0; i < arguments.length; i++) {
             if (i > 0) {
                 argBuf.append(", ");
             }
             argBuf.append(format(arguments[i], false));
         }
-        argBuf.append(ebdry);
+        argBuf.append(']');
         return argBuf.toString();
     }
 

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -601,7 +601,7 @@ public class InvokerHelper {
             }
         }
         if (arguments instanceof Collection) {
-            return formatList((Collection) arguments, verbose, maxSize);
+            return formatCollection((Collection) arguments, verbose, maxSize);
         }
         if (arguments instanceof Map) {
             return formatMap((Map) arguments, verbose, maxSize);
@@ -672,11 +672,11 @@ public class InvokerHelper {
         return maxSize == -1 ? maxSize : Math.max(0, maxSize - buffer.length());
     }
 
-    private static String formatList(Collection collection, boolean verbose, int maxSize) {
-        return formatList(collection, verbose, maxSize, false);
+    private static String formatCollection(Collection collection, boolean verbose, int maxSize) {
+        return formatCollection(collection, verbose, maxSize, false);
     }
 
-    private static String formatList(Collection collection, boolean verbose, int maxSize, boolean safe) {
+    private static String formatCollection(Collection collection, boolean verbose, int maxSize, boolean safe) {
         StringBuilder buffer = new StringBuilder(ITEM_ALLOCATE_SIZE * collection.size());
         buffer.append('[');
         boolean first = true;
@@ -784,7 +784,7 @@ public class InvokerHelper {
      * @return the string representation of the collection
      */
     public static String toListString(Collection arg, int maxSize, boolean safe) {
-        return formatList(arg, false, maxSize, safe);
+        return formatCollection(arg, false, maxSize, safe);
     }
 
     /**

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -124,14 +124,10 @@ public class InvokerHelper {
     }
 
     public static String toString(Object arguments) {
-        if (arguments instanceof Object[]) {
-            return toArrayString((Object[]) arguments);
-        }
-        if (arguments instanceof Collection) {
+        if (arguments instanceof Range) {
+            // for historic reasons, toString() formats Ranges by printing
+            // them as a list, whereas format prints them in .. notation
             return toListString((Collection) arguments);
-        }
-        if (arguments instanceof Map) {
-            return toMapString((Map) arguments);
         }
         return format(arguments, false);
     }

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -590,7 +590,7 @@ public class InvokerHelper {
             if (arguments instanceof char[]) {
                 return new String((char[]) arguments);
             }
-            return format(DefaultTypeTransformation.asCollection(arguments), verbose, maxSize);
+            return formatCollection(DefaultTypeTransformation.arrayAsCollection(arguments), verbose, maxSize);
         }
         if (arguments instanceof Range) {
             Range range = (Range) arguments;

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -124,11 +124,6 @@ public class InvokerHelper {
     }
 
     public static String toString(Object arguments) {
-        if (arguments instanceof Range) {
-            // for historic reasons, toString() formats Ranges by printing
-            // them as a list, whereas format prints them in .. notation
-            return toListString((Collection) arguments);
-        }
         return format(arguments, false);
     }
 

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -587,9 +587,13 @@ public class InvokerHelper {
             return (String) nullObject.getMetaClass().invokeMethod(nullObject, "toString", EMPTY_ARGS);
         }
         if (arguments.getClass().isArray()) {
+            if (arguments instanceof Object[]) {
+                return toArrayString((Object[]) arguments, verbose, maxSize, false);
+            }
             if (arguments instanceof char[]) {
                 return new String((char[]) arguments);
             }
+            // other primitives
             return formatCollection(DefaultTypeTransformation.arrayAsCollection(arguments), verbose, maxSize);
         }
         if (arguments instanceof Range) {

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -795,16 +795,45 @@ public class InvokerHelper {
      * @return the string representation of the array
      */
     public static String toArrayString(Object[] arguments) {
-        if (arguments == null) {
+        return toArrayString(arguments, false, -1, false);
+    }
+
+    private static String toArrayString(Object[] collection, boolean verbose, int maxSize, boolean safe) {
+        if (collection == null) {
             return "null";
         }
-        StringBuilder argBuf = new StringBuilder(arguments.length);
+        boolean first = true;
+        StringBuilder argBuf = new StringBuilder(collection.length);
         argBuf.append('[');
-        for (int i = 0; i < arguments.length; i++) {
-            if (i > 0) {
+
+        for (Object item : collection) {
+            if (first) {
+                first = false;
+            } else {
                 argBuf.append(", ");
             }
-            argBuf.append(format(arguments[i], false));
+            if (maxSize != -1 && argBuf.length() > maxSize) {
+                argBuf.append("...");
+                break;
+            }
+            if (item == collection) {
+                argBuf.append("(this Collection)");
+            } else {
+                String str;
+                try {
+                    str = format(item, verbose, sizeLeft(maxSize, argBuf));
+                } catch (Exception ex) {
+                    if (!safe) throw new GroovyRuntimeException(ex);
+                    String hash;
+                    try {
+                        hash = Integer.toHexString(item.hashCode());
+                    } catch (Exception ignored) {
+                        hash = "????";
+                    }
+                    str = "<" + item.getClass().getName() + "@" + hash + ">";
+                }
+                argBuf.append(str);
+            }
         }
         argBuf.append(']');
         return argBuf.toString();
@@ -820,7 +849,7 @@ public class InvokerHelper {
      * @return the string representation of the array
      */
     public static String toArrayString(Object[] arguments, int maxSize, boolean safe) {
-        return toListString(DefaultTypeTransformation.asCollection(arguments), maxSize, safe);
+        return toArrayString(arguments, false, maxSize, safe);
     }
 
     public static List createRange(Object from, Object to, boolean inclusive) {

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -121,12 +121,15 @@ public class InvokerHelper {
     }
 
     public static String toString(Object arguments) {
-        if (arguments instanceof Object[])
+        if (arguments instanceof Object[]) {
             return toArrayString((Object[]) arguments);
-        if (arguments instanceof Collection)
+        }
+        if (arguments instanceof Collection) {
             return toListString((Collection) arguments);
-        if (arguments instanceof Map)
+        }
+        if (arguments instanceof Map) {
             return toMapString((Map) arguments);
+        }
         return format(arguments, false);
     }
 

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -670,7 +670,11 @@ public class InvokerHelper {
                 break;
             }
             Map.Entry entry = (Map.Entry) o;
-            buffer.append(format(entry.getKey(), verbose));
+            if (entry.getKey() == map) {
+                buffer.append("(this Map)");
+            } else {
+                buffer.append(format(entry.getKey(), verbose, sizeLeft(maxSize, buffer), safe));
+            }
             buffer.append(":");
             if (entry.getValue() == map) {
                 buffer.append("(this Map)");

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -597,10 +597,18 @@ public class InvokerHelper {
         }
         if (arguments instanceof Range) {
             Range range = (Range) arguments;
-            if (verbose) {
-                return range.inspect();
-            } else {
-                return range.toString();
+            try {
+                if (verbose) {
+                    return range.inspect();
+                } else {
+                    return range.toString();
+                }
+            } catch (RuntimeException ex) {
+                if (!safe) throw  ex;
+                return handleFormattingException(arguments, ex);
+            } catch (Exception ex) {
+                if (!safe) throw  new GroovyRuntimeException(ex);
+                return handleFormattingException(arguments, ex);
             }
         }
         if (arguments instanceof Collection) {
@@ -640,16 +648,24 @@ public class InvokerHelper {
 //        return (String) invokeMethod(arguments, "toString", EMPTY_ARGS);
         try {
             return arguments.toString();
+        } catch (RuntimeException ex) {
+            if (!safe) throw  ex;
+            return handleFormattingException(arguments, ex);
         } catch (Exception ex) {
-            if (!safe) throw new GroovyRuntimeException(ex);
-            String hash;
-            try {
-                hash = Integer.toHexString(arguments.hashCode());
-            } catch (Exception ignored) {
-                hash = "????";
-            }
-            return "<" + arguments.getClass().getName() + "@" + hash + ">";
+            if (!safe) throw  new GroovyRuntimeException(ex);
+            return handleFormattingException(arguments, ex);
         }
+    }
+
+    private static String handleFormattingException(Object item, Exception ex) {
+
+        String hash;
+        try {
+            hash = Integer.toHexString(item.hashCode());
+        } catch (Exception ignored) {
+            hash = "????";
+        }
+        return "<" + item.getClass().getName() + "@" + hash + ">";
     }
 
     private static String formatMap(Map map, boolean verbose, int maxSize, boolean safe) {

--- a/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
@@ -1,0 +1,73 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.runtime
+
+class InvokerHelperFormattingTest extends GroovyTestCase {
+
+    public void testPrintLiterals() {
+        assert 'null' == InvokerHelper.toString(null)
+        assert '0.5' == InvokerHelper.toString(0.5)
+        assert '2' == InvokerHelper.toString(2)
+        assert '2' == InvokerHelper.toString(2L)
+        assert 'a' == InvokerHelper.toString('a')
+        assert 'a\'b' == InvokerHelper.toString('a\'b')
+    }
+
+    public void testPrintLists() {
+        assert '[]' == InvokerHelper.toString([])
+        assert '[1, true, a, \'b\']' == InvokerHelper.toString([1, true, 'a, \'b\''])
+    }
+
+    public void testPrintRanges() {
+        assert '[1, 2, 3, 4]' == InvokerHelper.toString(1..4)
+        assert "[a'b, a'c, a'd]" == InvokerHelper.toString('a\'b'..'a\'d')
+    }
+
+    public void testPrintArrays() {
+        assert "[a, a'b]" == InvokerHelper.toString(['a', 'a\'b'] as String[])
+        assert "[a, a'b]" == InvokerHelper.toString(['a', 'a\'b'] as Object[])
+    }
+
+    public void testPrintMaps() {
+        assert '[:]' == InvokerHelper.toString([:])
+        assert "[a'b:1, 2:b'c]" == InvokerHelper.toString(['a\'b':1, 2:'b\'c'])
+    }
+
+    public void testEmbedded() {
+        List list = []
+        list.add(['a\'b': 'c\'d'])
+        list.add(['e', 'f', 'g'])
+        list.add(5..9)
+        list.add('fog'..'fop')
+        list.add(['h', 'i'] as String[])
+        list.add([10, 11] as int[])
+        assert "[key:[[a'b:c'd], [e, f, g], 5..9, fog..fop, [h, i], [10, 11]]]" == InvokerHelper.toString([key: list])
+    }
+
+    public void testPrintSelfContained() {
+        List l = [];
+        l.add(l)
+        assert '[(this Collection)]' == InvokerHelper.toString(l)
+
+        Map m = [:]
+        m.put('x', m)
+        assert '[x:(this Map)]' == InvokerHelper.toString(m)
+    }
+
+}

--- a/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
@@ -20,6 +20,20 @@ package org.codehaus.groovy.runtime
 
 class InvokerHelperFormattingTest extends GroovyTestCase {
 
+    private static class ExceptionOnToString implements Comparable {
+        public static final String MATCHER = '<org.codehaus.groovy.runtime.InvokerHelperFormattingTest\\$ExceptionOnToString@[0-9a-z]+>'
+
+        @Override
+        String toString() {
+            throw new UnsupportedOperationException("toString() throws Exception for Testing")
+        }
+
+        @Override
+        int compareTo(Object o) {
+            throw new UnsupportedOperationException("compareTo() throws Exception for Testing")
+        }
+    }
+
     public void testPrintLiterals() {
         assert 'null' == InvokerHelper.toString(null)
         assert '0.5' == InvokerHelper.toString(0.5)
@@ -27,26 +41,55 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         assert '2' == InvokerHelper.toString(2L)
         assert 'a' == InvokerHelper.toString('a')
         assert 'a\'b' == InvokerHelper.toString('a\'b')
+        assert '\'a\\\'b\'' == InvokerHelper.toString('a\'b', true, -1, true)
+    }
+
+    public void testSafeFormant() {
+        try {
+            assert InvokerHelper.toString(new ExceptionOnToString())
+            fail('No Exception thrown')
+        } catch (UnsupportedOperationException e) {
+            // success
+        }
+        assert InvokerHelper.toString(new ExceptionOnToString(), false, -1, true) =~ (ExceptionOnToString.MATCHER)
     }
 
     public void testPrintLists() {
         assert '[]' == InvokerHelper.toString([])
         assert '[1, true, a, \'b\']' == InvokerHelper.toString([1, true, 'a, \'b\''])
+        Object eObject = new ExceptionOnToString()
+        assert InvokerHelper.toString([eObject], false, -1, true) =~ "\\[${ExceptionOnToString.MATCHER}\\]"
     }
 
     public void testPrintRanges() {
-        assert '[1, 2, 3, 4]' == InvokerHelper.toString(1..4)
-        assert "[a'b, a'c, a'd]" == InvokerHelper.toString('a\'b'..'a\'d')
+        assert '1..4' == InvokerHelper.toString(1..4)
+        assert "a'b..a'd" == InvokerHelper.toString('a\'b'..'a\'d')
+        assert "'a\\'b'..'a\\'d'" == InvokerHelper.toString('a\'b'..'a\'d', true, -1, false);
+        Object eObject = new ExceptionOnToString()
+        assert InvokerHelper.toString(eObject..eObject, false, -1, true) == '<groovy.lang.ObjectRange@????>'
     }
 
     public void testPrintArrays() {
         assert "[a, a'b]" == InvokerHelper.toString(['a', 'a\'b'] as String[])
         assert "[a, a'b]" == InvokerHelper.toString(['a', 'a\'b'] as Object[])
+
+        assert "['a', 'a\\'b']" == InvokerHelper.toString(['a', 'a\'b'] as String[], true, -1, true)
+        assert "['a', 'a\\'b']" == InvokerHelper.toString(['a', 'a\'b'] as Object[], true, -1, true)
+
+        assert InvokerHelper.toString([new ExceptionOnToString()] as Object[], false, -1, true) =~ "\\[${ExceptionOnToString.MATCHER}\\]"
     }
 
     public void testPrintMaps() {
         assert '[:]' == InvokerHelper.toString([:])
         assert "[a'b:1, 2:b'c]" == InvokerHelper.toString(['a\'b':1, 2:'b\'c'])
+        assert "['a\\'b':1, 2:'b\\'c']" == InvokerHelper.toString(['a\'b':1, 2:'b\'c'], true, -1, true)
+
+        Object eObject = new ExceptionOnToString()
+        assert InvokerHelper.toString([foo: eObject], false, -1, true) =~ "\\[foo:${ExceptionOnToString.MATCHER}\\]"
+        assert InvokerHelper.toString([foo: eObject], true, -1, true) =~ "\\['foo':${ExceptionOnToString.MATCHER}\\]"
+        Map m = [:]
+        m.put(eObject, eObject)
+        assert InvokerHelper.toString(m, false, -1, true) =~ "\\[${ExceptionOnToString.MATCHER}:${ExceptionOnToString.MATCHER}\\]"
     }
 
     public void testEmbedded() {
@@ -58,6 +101,7 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         list.add(['h', 'i'] as String[])
         list.add([10, 11] as int[])
         assert "[key:[[a'b:c'd], [e, f, g], 5..9, fog..fop, [h, i], [10, 11]]]" == InvokerHelper.toString([key: list])
+        assert "['key':[['a\\'b':'c\\'d'], ['e', 'f', 'g'], 5..9, 'fog'..'fop', ['h', 'i'], [10, 11]]]" == InvokerHelper.toString([key:list], true, -1, false)
     }
 
     public void testPrintSelfContained() {
@@ -66,8 +110,8 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         assert '[(this Collection)]' == InvokerHelper.toString(l)
 
         Map m = [:]
-        m.put('x', m)
-        assert '[x:(this Map)]' == InvokerHelper.toString(m)
+        m.put(m, m)
+        assert '[(this Map):(this Map)]' == InvokerHelper.toString(m)
     }
 
 }


### PR DESCRIPTION
Changes the internal API of the formatting methods in InvokerHelper and also the output in some cases when using verbose or safe arguments.

This PR contains currently controversial changes to the formatting methods in InvokerHelper that could break client code. 

Further analysis and discussion required.

EDIT: This currently contains the commits from #96 (until that one is merged).