### PR TITLE
GROOVY-7610 Null safe is calls throw VerifyError when used as conditi…

### DIFF
--- a/src/main/org/codehaus/groovy/transform/sc/transformers/MethodCallExpressionTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/MethodCallExpressionTransformer.java
@@ -170,9 +170,10 @@ public class MethodCallExpressionTransformer {
      * @return null if the method call is not DGM#is, or {@link CompareIdentityExpression}
      */
     private static Expression tryTransformIsToCompareIdentity(MethodCallExpression call) {
+        if (call.isSafe()) return null;
         MethodNode methodTarget = call.getMethodTarget();
         if (methodTarget instanceof ExtensionMethodNode && "is".equals(methodTarget.getName()) && methodTarget.getParameters().length==1) {
-           methodTarget = ((ExtensionMethodNode) methodTarget).getExtensionMethodNode();
+            methodTarget = ((ExtensionMethodNode) methodTarget).getExtensionMethodNode();
             ClassNode owner = methodTarget.getDeclaringClass();
             if (DGM_CLASSNODE.equals(owner)) {
                 Expression args = call.getArguments();

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
@@ -1393,5 +1393,22 @@ println someInt
             assert foo.name == 'fluent'
         '''
     }
+
+    // GROOVY-7610
+    void testNullSafeIsCallConditionShouldNotThrowVerifyError() {
+        assertScript '''
+            class A {
+                void ifCondition(Object x, Object y) {
+                    if (x?.is(y))
+                        return
+                }
+
+                void ternaryCondition(Object x, Object y) {
+                    x?.is(y) ? 'foo' : 'bar'
+                }
+            }
+            new A()
+        '''
+    }
 }
 


### PR DESCRIPTION
…on with CompileStatic

* Null safe .is method call expressions were being transformed to CompareIdentityExpressions