### PR TITLE
GROOVY-3341: If an exception is thrown from a builder closure, wrap i…

### DIFF
--- a/src/main/groovy/util/BuilderSupport.java
+++ b/src/main/groovy/util/BuilderSupport.java
@@ -20,6 +20,7 @@ package groovy.util;
 
 import groovy.lang.Closure;
 import groovy.lang.GroovyObjectSupport;
+import groovy.lang.GroovyRuntimeException;
 import groovy.lang.MissingMethodException;
 import org.codehaus.groovy.runtime.InvokerHelper;
 
@@ -142,7 +143,11 @@ public abstract class BuilderSupport extends GroovyObjectSupport {
             setCurrent(node);
             // let's register the builder as the delegate
             setClosureDelegate(closure, node);
-            closure.call();
+            try {
+                closure.call();
+            } catch (Exception e) {
+                throw new GroovyRuntimeException(e);
+            }
             setCurrent(oldCurrent);
         }
 

--- a/src/test/groovy/util/BuilderSupportTest.groovy
+++ b/src/test/groovy/util/BuilderSupportTest.groovy
@@ -148,6 +148,19 @@ class BuilderSupportTest extends GroovyTestCase{
     void nestedBuilderCall(builder) {
         builder.inner()
     }
+
+    // GROOVY-7156
+    void testSimpleNodeWithClosureThatThrowsAMissingMethodException() {
+      def builder = new SpoofBuilder()
+      String errorMessage = shouldFail(MissingMethodException, {
+          builder.a {
+              b {
+                  error('xy'.foo())
+              }
+          }
+      })
+      assert errorMessage.contains('No signature of method: java.lang.String.foo()')
+  }
 }
 
 /**


### PR DESCRIPTION
…t in a GroovyRuntimeException, otherwise it would be reported as a missing methon on the closure

created out of patch https://issues.apache.org/jira/browse/GROOVY-3341 submitted by Jochen Kemnade
