### PR TITLE
GROOVY-7074: fix for using a Builder as delegate in a DelegatingScript

### DIFF
--- a/src/main/groovy/util/DelegatingScript.java
+++ b/src/main/groovy/util/DelegatingScript.java
@@ -107,7 +107,7 @@ public abstract class DelegatingScript extends Script {
     @Override
     public Object invokeMethod(String name, Object args) {
         try {
-            return metaClass.invokeMethod(delegate,name,args);
+            return InvokerHelper.invokeMethod(delegate, name, args);
         } catch (MissingMethodException mme) {
             return super.invokeMethod(name, args);
         }

--- a/src/test/groovy/util/DelegatingScriptTest.groovy
+++ b/src/test/groovy/util/DelegatingScriptTest.groovy
@@ -19,6 +19,8 @@
 package groovy.util
 
 import org.codehaus.groovy.control.CompilerConfiguration
+import groovy.xml.MarkupBuilder
+import java.io.StringWriter
 
 public class DelegatingScriptTest extends GroovyTestCase {
     public void testDelegatingScript() throws Exception {
@@ -36,6 +38,22 @@ public class DelegatingScriptTest extends GroovyTestCase {
         script.run();
         assert dsl.foo==6;
         assert dsl.innerBar()=='testset';
+    }
+
+    public void testUseMarkupBuilderAsDelegate() throws Exception {
+        def cc = new CompilerConfiguration()
+        cc.scriptBaseClass = DelegatingScript.class.name
+        def sh = new GroovyShell(new Binding(), cc)
+        def script = sh.parse(''' foo{ bar() }
+        ''')
+        StringWriter sw = new StringWriter()
+        def markupBuilder = new MarkupBuilder(sw)
+        script.setDelegate(markupBuilder)
+        script.run()
+
+        assert sw.toString() == """<foo>
+  <bar />
+</foo>"""
     }
 }
 


### PR DESCRIPTION
created out of patch https://issues.apache.org/jira/browse/GROOVY-7074 submitted by Jochen Kemnade