### PR TITLE
GROOVY-7598 Generic types are not checked for return statements (STC)

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -1816,6 +1816,8 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                         virtualDecl.visit(this);
                         ClassNode newlyInferred = (ClassNode) virtualDecl.getNodeMetaData(StaticTypesMarker.INFERRED_TYPE);
                         if (!missesGenericsTypes(newlyInferred)) type = newlyInferred;
+                    } else {
+                        checkTypeGenerics(enclosingMethod.getReturnType(), inferred, expression);
                     }
                     return type;
                 } else {

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -201,7 +201,7 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         ''', 'Cannot call java.util.LinkedList <String>#<init>(java.util.Collection <java.lang.Object extends java.lang.String>) with arguments [java.util.List <java.lang.Integer>]'
     }
 
-    void testCompatibleGenericAssignmentWithInferrence() {
+    void testCompatibleGenericAssignmentWithInference() {
         shouldFailWithMessages '''
             List<String> elements = ['a','b', 1]
         ''', 'Incompatible generic argument types. Cannot assign java.util.List <java.io.Serializable> to: java.util.List <String>'
@@ -1642,6 +1642,27 @@ assert result == 'ok'
             }
             Wrapper w = new Wrapper()
             assert new Foo<Wrapper>().doIt([w]) == w
+        '''
+    }
+
+    void testReturnTypeChecking() {
+        shouldFailWithMessages '''
+            class Foo {
+                List<String> run() {
+                    [11, 12]
+                }
+            }
+        ''', 'Incompatible generic argument types. Cannot assign java.util.List <java.lang.Integer> to: java.util.List <String>'
+    }
+
+    void testBoundedReturnTypeChecking() {
+        assertScript '''
+            class Foo {
+                List<? extends Serializable> run() {
+                    [1, 'a']
+                }
+            }
+            null
         '''
     }
 

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/ArraysAndCollectionsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/ArraysAndCollectionsStaticCompileTest.groovy
@@ -64,7 +64,7 @@ class ArraysAndCollectionsStaticCompileTest extends ArraysAndCollectionsSTCTest 
     // GROOVY-5988
     void testMapArraySetPropertyAssignment() {
         assertScript '''
-            Map<String, String> props(Object p) {
+            Map<String, Object> props(Object p) {
                 Map<String, Object> props = [:]
 
                 for(String property in p.properties.keySet()){


### PR DESCRIPTION
Though this is something I had assumed was already in place, it could be a breaking change given that I had to slightly modify a unit test.