### PR TITLE
GROOVY-7623 Use ClassValue by default on IBM Java

### DIFF
--- a/src/main/org/codehaus/groovy/reflection/GroovyClassValueFactory.java
+++ b/src/main/org/codehaus/groovy/reflection/GroovyClassValueFactory.java
@@ -27,8 +27,9 @@ class GroovyClassValueFactory {
 	 * This flag is introduced as a (hopefully) temporary workaround for a JVM bug, that is to say that using
 	 * ClassValue prevents the classes and classloaders from being unloaded.
 	 * See https://bugs.openjdk.java.net/browse/JDK-8136353
+	 * This issue does not exist on IBM Java (J9) so use ClassValue by default on that JVM. 
 	 */
-	private final static boolean USE_CLASSVALUE = Boolean.valueOf(System.getProperty("groovy.use.classvalue", "false"));
+	private final static boolean USE_CLASSVALUE = Boolean.valueOf(System.getProperty("groovy.use.classvalue", "IBM J9 VM".equals(System.getProperty("java.vm.name"))?"true":"false"));
 
 	private static final Constructor groovyClassValueConstructor;
 


### PR DESCRIPTION
IBM Java doesn't have the ClassValue garbage collection issue that OpenJDK has (https://bugs.openjdk.java.net/browse/JDK-8136353) so when running on that JVM, enable ClassValue by default.

https://issues.apache.org/jira/browse/GROOVY-7623