### PR TITLE
Corrected bitwiseNegate in operators documentation

### DIFF
--- a/src/spec/doc/core-operators.adoc
+++ b/src/spec/doc/core-operators.adoc
@@ -795,6 +795,6 @@ Here is a complete list of the operators and their corresponding methods:
 | `a()`
 | a.call()
 | `~a`
-| a.bitwiseNegative()
+| a.bitwiseNegate()
 |====
 


### PR DESCRIPTION
`bitwiseNegative` should `bitwiseNegate` in the `Operator overloading` documentation (see http://docs.groovy-lang.org/docs/latest/html/documentation/core-domain-specific-languages.html#_operator_overloading)