### PR TITLE
GROOVY-5380: Add Ctrl+L/Ctrl+B for line/block selection

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/ConsoleActions.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/ConsoleActions.groovy
@@ -385,3 +385,11 @@ commentAction = action(
     accelerator: KeyStroke.getKeyStroke(KeyEvent.VK_SLASH, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()),
     shortDescription: 'Comment/Uncomment Selected Script'
 )
+
+selectBlockAction = action(
+    name: 'Select Block',
+    closure: controller.&selectBlock,
+    mnemonic: 'B',
+    accelerator: shortcut('B'),
+    shortDescription: 'Selects current Word, Line or Block in Script'
+)

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/ConsoleView.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/ConsoleView.groovy
@@ -22,6 +22,9 @@ import groovy.ui.view.Defaults
 import groovy.ui.view.GTKDefaults
 import groovy.ui.view.MacOSXDefaults
 import groovy.ui.view.WindowsDefaults
+
+import javax.swing.Action
+import javax.swing.text.DefaultEditorKit
 import java.awt.datatransfer.DataFlavor
 import java.awt.dnd.*
 import javax.swing.UIManager
@@ -105,6 +108,12 @@ controller.origDividerSize = origDividerSize
 controller.splitPane = splitPane
 controller.blank = blank
 controller.scrollArea = scrollArea
+controller.selectWordAction = inputArea.getActions().find {
+    DefaultEditorKit.selectWordAction.equals(it.getValue(Action.NAME))
+}
+controller.selectPreviousWordAction = inputArea.getActions().find {
+    DefaultEditorKit.selectionPreviousWordAction.equals(it.getValue(Action.NAME))
+}
 
 // some more UI linkage
 controller.outputArea.addComponentListener(controller)

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/view/BasicMenuBar.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/view/BasicMenuBar.groovy
@@ -52,6 +52,7 @@ menuBar {
         menuItem(selectAllAction)
 	separator()
 	menuItem(commentAction)
+        menuItem(selectBlockAction)
     }
 
     menu(text: 'View', mnemonic: 'V') {

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/view/MacOSXMenuBar.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/view/MacOSXMenuBar.groovy
@@ -85,6 +85,7 @@ menuBar {
         menuItem(selectAllAction, icon:null)
 	separator()
 	menuItem(commentAction, icon:null)
+        menuItem(selectBlockAction, icon:null)
     }
 
     menu(text: 'View', mnemonic: 'V') {


### PR DESCRIPTION
Implemented Ctrl+B (Select Block) to handle selecting a word, line and block.  If nothing is currently selected the action will select the next chunk unless at the end of the line then the previous chunk will be selected.  If there is already a partial selection on a line, then the entire line will be selected.  If an entire line or multiple lines are already selected then the block/paragraph will be selected.