### PR TITLE
Fixed the typo in the documentation on http://www.groovy-lang.org/processing-xml.html page.

### DIFF
--- a/subprojects/groovy-xml/src/spec/doc/xml-userguide.adoc
+++ b/subprojects/groovy-xml/src/spec/doc/xml-userguide.adoc
@@ -211,7 +211,7 @@ include::{rootProjectDir}/subprojects/groovy-xml/src/spec/test/UserGuideXmlSlurp
 <4> Getting the value as a String
 <5> Getting the value of the attribute as an `Integer`
 
-As you can see there are to types of notations to get attributes,
+As you can see there are two types of notations to get attributes,
 the
 
 * _direct notation_ with `@nameoftheattribute`


### PR DESCRIPTION
update the line "As you can see there are to types of notations to get attributes"
to "As you can see there are two types of notations to get attributes"

![screenshot from 2015-10-22 10-41-33](https://cloud.githubusercontent.com/assets/6151462/10657528/8b83a1ea-78aa-11e5-9a7c-6bd8a701c7e0.png)
