### PR TITLE
GROOVY-4888 - fix so child threads output/err streams go to correct console

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/SystemOutputInterceptor.java
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/SystemOutputInterceptor.java
@@ -32,7 +32,7 @@ public class SystemOutputInterceptor extends FilterOutputStream {
     private Closure callback;
     private boolean output;
 
-    private static final ThreadLocal<Integer> consoleId = new ThreadLocal<Integer>() {
+    private static final ThreadLocal<Integer> consoleId = new InheritableThreadLocal<Integer>() {
         @Override
         protected Integer initialValue() {
             return Integer.valueOf(0);


### PR DESCRIPTION
@PascalSchumacher sorry for the extra trouble, I forgot to include this minor change in the original PR #160.  This makes it so that any new Thread's started in the console script itself output stdout/stderr to the correct console output area.