### PR TITLE
GROOVY-6669 - Compile in groovyConsole instantiates class

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
@@ -1091,7 +1091,7 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
         runThread = Thread.start {
             try {
                 SwingUtilities.invokeLater { showCompilingMessage() }
-                shell.parse(record.allText)
+                shell.getClassLoader().parseClass(record.allText)
                 SwingUtilities.invokeLater { compileFinishNormal() }
             } catch (Throwable t) {
                 SwingUtilities.invokeLater { finishException(t, false) }


### PR DESCRIPTION
For scripts that contain Class definitions the `GroovyShell#parse` [[1]](https://github.com/apache/incubator-groovy/blob/d1979d119f805f721600c114466311b928c4c587/src/main/groovy/lang/GroovyShell.java#L700) calls `InvokeHelper#createScript` which creates a new instance in order to bind properties [[2]](https://github.com/apache/incubator-groovy/blob/d1979d119f805f721600c114466311b928c4c587/src/main/org/codehaus/groovy/runtime/InvokerHelper.java#L436-L460).  The compile command should only parse the class to make sure there are no syntax errors so this fix just calls the same `GroovyClassLoader#parseClass` method that the `GroovyShell#run` command uses.

With this change the following will compile:

```groovy
class OtherThing {
    OtherThing() {
        def v = null
        v.hashCode()
    }
}
```
If one of the braces is left off:

```groovy
 class OtherThing {
    OtherThing() {
        def v = null
        v.hashCode()
    
}
```
The following compilation error occurs:

```
1 compilation error:

expecting '}', found '' at line: 6, column: 2
```