### PR TITLE
Non-atomic use of atomicCategoryUsageCounter

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/GroovyCategorySupport.java
+++ b/src/main/org/codehaus/groovy/runtime/GroovyCategorySupport.java
@@ -72,8 +72,7 @@ public class GroovyCategorySupport {
         private Map<String, String> propertySetterMap;
 
         private void newScope () {
-            atomicCategoryUsageCounter.incrementAndGet();
-            categoriesInUse = atomicCategoryUsageCounter.get();
+            categoriesInUse = atomicCategoryUsageCounter.incrementAndGet();
             DefaultMetaClassInfo.setCategoryUsed(true);
             VMPluginFactory.getPlugin().invalidateCallSites();
             level++;
@@ -96,8 +95,7 @@ public class GroovyCategorySupport {
                 }
             }
             level--;
-            atomicCategoryUsageCounter.getAndDecrement();
-            categoriesInUse = atomicCategoryUsageCounter.get();
+            categoriesInUse = atomicCategoryUsageCounter.decrementAndGet();
             VMPluginFactory.getPlugin().invalidateCallSites();
             if (categoriesInUse==0) DefaultMetaClassInfo.setCategoryUsed(false);
             if (level == 0) {


### PR DESCRIPTION
The atomicCategoryUsageCounter was Incremented/decremented on one line and and then read on the next line leaving a small window for race conditions to happen.  This is a possible fix for https://issues.apache.org/jira/browse/GROOVY-7535
