### PR TITLE
fix after #172, Interpretermode tests also need to run all other tests

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -354,7 +354,7 @@ try {$COLLECTED_BOUND_VARS_MAP_VARNAME[\"$varname\"] = $varname;
     /**
      * Format the given number suitable for rendering as a line number column.
      */
-    private String formatLineNumber(final int num) {
+    protected String formatLineNumber(final int num) {
         assert num >= 0
 
         // Make a %03d-like string for the line number
@@ -407,7 +407,7 @@ try {$COLLECTED_BOUND_VARS_MAP_VARNAME[\"$varname\"] = $varname;
     // Recording
     //
 
-    private void maybeRecordInput(final String line) {
+    protected void maybeRecordInput(final String line) {
         RecordCommand record = registry[RecordCommand.COMMAND_NAME]
 
         if (record != null) {
@@ -415,7 +415,7 @@ try {$COLLECTED_BOUND_VARS_MAP_VARNAME[\"$varname\"] = $varname;
         }
     }
 
-    private void maybeRecordResult(final Object result) {
+    protected void maybeRecordResult(final Object result) {
         RecordCommand record = registry[RecordCommand.COMMAND_NAME]
 
         if (record != null) {
@@ -423,7 +423,7 @@ try {$COLLECTED_BOUND_VARS_MAP_VARNAME[\"$varname\"] = $varname;
         }
     }
 
-    private void maybeRecordError(Throwable cause) {
+    protected void maybeRecordError(Throwable cause) {
         RecordCommand record = registry[RecordCommand.COMMAND_NAME]
 
         if (record != null) {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -39,7 +39,6 @@ class GroovyshTest extends GroovyTestCase {
         mockErr = new ByteArrayOutputStream()
         testio = new IO(new ByteArrayInputStream(), mockOut, mockErr)
         testio.setVerbosity(IO.Verbosity.INFO)
-        Preferences.put(Groovysh.INTERPRETER_MODE_PREFERENCE_KEY, 'false')
     }
 
     void testCompleteExpr() {
@@ -49,8 +48,20 @@ class GroovyshTest extends GroovyTestCase {
         assert ' 3\n' == mockOut.toString().normalize()[-3..-1]
     }
 
+    protected Groovysh createGroovysh() {
+        return new Groovysh(testio) {
+            @Override
+            protected String getPreference(String key, String theDefault) {
+                if (key == INTERPRETER_MODE_PREFERENCE_KEY) {
+                    return 'false'
+                }
+                return super.getPreference(key, theDefault)
+            }
+        }
+    }
+
     void testClassDef() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.execute('class MyFooTestClass{ String foo }')
         assert mockOut.toString().length() > 0
         assert ' true\n' == mockOut.toString().normalize()[-6..-1]
@@ -62,7 +73,7 @@ class GroovyshTest extends GroovyTestCase {
 
 
     void testmethodDef() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.execute('int foo() {42}')
         assert mockOut.toString().length() > 0
         assert ' true\n' == mockOut.toString().normalize()[-6..-1]
@@ -71,13 +82,13 @@ class GroovyshTest extends GroovyTestCase {
 
 
     void testIncompleteExpr() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.execute('def x() {')
         assert '' == mockOut.toString()
     }
 
     void testBadExpr() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         try {
             groovysh.execute('x}')
             fail('expected MultipleCompilationErrorsException ')
@@ -87,14 +98,14 @@ class GroovyshTest extends GroovyTestCase {
     }
 
     void testMissingPropertyExpr() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         // this is a special case, e.g. happens for Gradle DefaultExtraPropertiesExtension
         // assert no fail
         groovysh.execute(/x = new Object() {public Object getProperty(String name) {throw new MissingPropertyException('From test', name, null)}}/)
     }
 
     void testDisplayBuffer() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.displayBuffer(['foo', 'bar'])
         def out = mockOut.toString().normalize()
         // was 20 on my windows box after normalize()
@@ -105,14 +116,14 @@ class GroovyshTest extends GroovyTestCase {
     }
 
     void testDefaultErrorHook() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultErrorHook(new Throwable() {
             StackTraceElement[] stackTrace = [
                     new StackTraceElement('fooClass', 'fooMethod', 'fooFile', 42),
                     new StackTraceElement(Interpreter.SCRIPT_FILENAME, 'run', 'scriptFile', 42)]
         })
         assert '' == mockOut.toString()
-        assert mockErr.toString().contains('org.codehaus.groovy.tools.shell.GroovyshTest$1')
+        assert mockErr.toString().contains('org.codehaus.groovy.tools.shell.GroovyshTest$')
         assert mockErr.toString().contains('fooClass')
         assert mockErr.toString().contains('foo')
         assert ! mockErr.toString().contains(Interpreter.SCRIPT_FILENAME)
@@ -120,63 +131,63 @@ class GroovyshTest extends GroovyTestCase {
     }
 
     void testDefaultResultHookStringArray() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook('foo bar'.split())
         assert mockOut.toString().trim().endsWith('[foo, bar]')
         assert '' == mockErr.toString()
     }
 
     void testDefaultResultHookObjectArray() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook(Object.fields)
         assert mockOut.toString().trim().endsWith('[]')
         assert '' == mockErr.toString()
     }
 
     void testDefaultResultPrimitive() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook(3)
         assert mockOut.toString().trim().endsWith('3')
         assert '' == mockErr.toString()
     }
 
     void testDefaultResultNull() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook(null)
         assert mockOut.toString().trim().endsWith('null')
         assert '' == mockErr.toString()
     }
 
     void testDefaultResultList() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook([])
         assert mockOut.toString().trim().endsWith('[]')
         assert '' == mockErr.toString()
     }
 
     void testDefaultResultSet() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook([42] as Set)
         assert mockOut.toString().trim().endsWith('[42]')
         assert '' == mockErr.toString()
     }
 
     void testDefaultResultArray() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook([42] as int[])
         assert mockOut.toString().trim().endsWith('[42]')
         assert '' == mockErr.toString()
     }
 
     void testDefaultResultMapEmpty() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook([:])
         assert mockOut.toString().trim().endsWith('[:]')
         assert '' == mockErr.toString()
     }
 
     void testDefaultResultMap() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.defaultResultHook(['class': 'foo'])
         assert mockOut.toString().trim().endsWith('[class:foo]')
         assert '' == mockErr.toString()
@@ -184,7 +195,7 @@ class GroovyshTest extends GroovyTestCase {
 
     void testDefaultResultConfigObject() {
         // ConfigObject are like maps
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         ConfigObject co = new ConfigObject()
         co.put('class', 'foo')
         groovysh.defaultResultHook(co)
@@ -193,7 +204,7 @@ class GroovyshTest extends GroovyTestCase {
     }
 
     void testFindCommandDuplicate() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         CommandSupport command = new CommandSupport(groovysh, 'import', 'imp') {
             @Override
             Object execute(List args) {
@@ -209,7 +220,7 @@ class GroovyshTest extends GroovyTestCase {
     }
 
     void testFindCommandFoo() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         assertNull(groovysh.findCommand(' foo import '))
         assert !groovysh.isExecutable(' foo import ')
         CommandSupport command2 = new CommandSupport(groovysh, 'foo', '/foo') {
@@ -233,7 +244,7 @@ class GroovyshTest extends GroovyTestCase {
     }
 
     void testExecuteCommandFoo() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         assertNull(groovysh.findCommand(' foo import '))
         assert ! groovysh.isExecutable(' foo import ')
         CommandSupport command2 = new CommandSupport(groovysh, 'foo', '/foo') {
@@ -251,7 +262,7 @@ class GroovyshTest extends GroovyTestCase {
     }
 
     void testGetIndentLevel() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         assert '' == groovysh.indentPrefix
         groovysh.buffers.buffers.add(['Foo {'])
         groovysh.buffers.select(1)
@@ -263,7 +274,7 @@ class GroovyshTest extends GroovyTestCase {
 
     void testLoadUserScript() {
         final File file = createTemporaryGroovyScriptFile('1 / 0')
-        Groovysh groovysh = new Groovysh(testio) {
+        Groovysh groovysh = new Groovysh() {
             @Override
             File getUserStateDirectory() {
                 return file.parentFile
@@ -276,7 +287,7 @@ class GroovyshTest extends GroovyTestCase {
     }
 
     void testImports() {
-        Groovysh groovysh = new Groovysh(testio)
+        Groovysh groovysh = createGroovysh()
         groovysh.execute('import java.rmi.Remote ')
         assert mockOut.toString().length() > 0
         assert 'java.rmi.Remote\n' == mockOut.toString().normalize()[-('java.rmi.Remote\n'.length())..-1]
@@ -300,8 +311,8 @@ class GroovyshTest extends GroovyTestCase {
  */
 class GroovyshInterpreterModeTest extends GroovyshTest {
 
-    void testBoundVar() {
-        Groovysh groovysh = new Groovysh(testio) {
+    protected Groovysh createGroovysh() {
+        return new Groovysh(testio) {
             @Override
             protected String getPreference(String key, String theDefault) {
                 if (key == INTERPRETER_MODE_PREFERENCE_KEY) {
@@ -310,6 +321,10 @@ class GroovyshInterpreterModeTest extends GroovyshTest {
                 return super.getPreference(key, theDefault)
             }
         }
+    }
+
+    void testBoundVar() {
+        Groovysh groovysh = createGroovysh()
 
         groovysh.execute('int x = 3')
         assert mockOut.toString().length() > 0
@@ -320,15 +335,7 @@ class GroovyshInterpreterModeTest extends GroovyshTest {
     }
 
     void testBoundVarmultiple() {
-        Groovysh groovysh = new Groovysh(testio) {
-            @Override
-            protected String getPreference(String key, String theDefault) {
-                if (key == INTERPRETER_MODE_PREFERENCE_KEY) {
-                    return 'true'
-                }
-                return super.getPreference(key, theDefault)
-            }
-        }
+        Groovysh groovysh = createGroovysh()
         groovysh.execute('int x, y, z')
         assert mockOut.toString().length() > 0
         assert ' 0\n' == mockOut.toString().normalize()[-3..-1]


### PR DESCRIPTION
Sorry, I did not think that through. #172 is bad because it makes many tests from parent test class run without proper configuration.