### PR TITLE
GROOVY-4847 - Missing GDK rounding (and trunc) methods for BigDecimal

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -61,6 +61,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.net.MalformedURLException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -15077,6 +15078,68 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
             return Math.ceil(number *Math.pow(10,precision))/Math.pow(10,precision);
         }
         return Math.floor(number *Math.pow(10,precision))/Math.pow(10,precision);
+    }
+
+    /**
+     * Round the value
+     * <p>
+     * Note that this method differs from {@link java.math.BigDecimal#round(java.math.MathContext)}
+     * which specifies the digits to retain starting from the leftmost nonzero
+     * digit. This methods rounds the integral part to the nearest whole number.
+     *
+     * @param number a BigDecimal
+     * @return the rounded value of that BigDecimal
+     * @see #round(java.math.BigDecimal, int)
+     * @see java.math.BigDecimal#round(java.math.MathContext)
+     * @since 2.5.0
+     */
+    public static BigDecimal round(BigDecimal number) {
+        return round(number, 0);
+    }
+
+    /**
+     * Round the value
+     * <p>
+     * Note that this method differs from {@link java.math.BigDecimal#round(java.math.MathContext)}
+     * which specifies the digits to retain starting from the leftmost nonzero
+     * digit. This method operates on the fractional part of the number and
+     * the precision argument specifies the number of digits to the right of
+     * the decimal point to retain.
+     *
+     * @param number a BigDecimal
+     * @param precision the number of decimal places to keep
+     * @return a BigDecimal rounded to the number of decimal places specified by precision
+     * @see #round(java.math.BigDecimal)
+     * @see java.math.BigDecimal#round(java.math.MathContext)
+     * @since 2.5.0
+     */
+    public static BigDecimal round(BigDecimal number, int precision) {
+        return number.setScale(precision, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Truncate the value
+     *
+     * @param number a BigDecimal
+     * @return a BigDecimal truncated to 0 decimal places
+     * @see #trunc(java.math.BigDecimal, int)
+     * @since 2.5.0
+     */
+    public static BigDecimal trunc(BigDecimal number) {
+        return trunc(number, 0);
+    }
+
+    /**
+     * Truncate the value
+     *
+     * @param number a BigDecimal
+     * @param precision the number of decimal places to keep
+     * @return a BigDecimal truncated to the number of decimal places specified by precision
+     * @see #trunc(java.math.BigDecimal)
+     * @since 2.5.0
+     */
+    public static BigDecimal trunc(BigDecimal number, int precision) {
+        return number.setScale(precision, RoundingMode.DOWN);
     }
 
     /**

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -62,6 +62,27 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertEquals(DefaultGroovyMethods.round(d, 6), 1000.123456);
     }
 
+    public void testBigDecimalRounding() throws Exception {
+        BigDecimal bd = new BigDecimal('1000.123456')
+
+        assertEquals(DefaultGroovyMethods.round(bd), new BigDecimal('1000'));
+        assertEquals(DefaultGroovyMethods.round(bd, 0), new BigDecimal('1000.0'));
+        assertEquals(DefaultGroovyMethods.round(bd, 1), new BigDecimal('1000.1'));
+        assertEquals(DefaultGroovyMethods.round(bd, 2), new BigDecimal('1000.12'));
+        assertEquals(DefaultGroovyMethods.round(bd, 3), new BigDecimal('1000.123'));
+        assertEquals(DefaultGroovyMethods.round(bd, 4), new BigDecimal('1000.1235'));
+        assertEquals(DefaultGroovyMethods.round(bd, 5), new BigDecimal('1000.12346'));
+        assertEquals(DefaultGroovyMethods.round(bd, 6), new BigDecimal('1000.123456'));
+
+        BigDecimal bd2 = new BigDecimal('-123.739')
+
+        assertEquals(DefaultGroovyMethods.round(bd2), new BigDecimal('-124'));
+        assertEquals(DefaultGroovyMethods.round(bd2, 0), new BigDecimal('-124.0'));
+        assertEquals(DefaultGroovyMethods.round(bd2, 1), new BigDecimal('-123.7'));
+        assertEquals(DefaultGroovyMethods.round(bd2, 2), new BigDecimal('-123.74'));
+        assertEquals(DefaultGroovyMethods.round(bd2, 3), new BigDecimal('-123.739'));
+    }
+
     public void testFloatTruncate() throws Exception {
         Float f = 1000.123456f;
 
@@ -100,6 +121,26 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertEquals(DefaultGroovyMethods.trunc(d2, 0), -123.0d)
         assertEquals(DefaultGroovyMethods.trunc(d2, 1), -123.7d)
         assertEquals(DefaultGroovyMethods.trunc(d2, 2), -123.73d)
+    }
+
+    public void testBigDecimalTruncate() throws Exception {
+        BigDecimal bd = new BigDecimal('1000.123456')
+
+        assertEquals(DefaultGroovyMethods.trunc(bd), new BigDecimal('1000.0'))
+        assertEquals(DefaultGroovyMethods.trunc(bd, 0), new BigDecimal('1000.0'))
+        assertEquals(DefaultGroovyMethods.trunc(bd, 1), new BigDecimal('1000.1'))
+        assertEquals(DefaultGroovyMethods.trunc(bd, 2), new BigDecimal('1000.12'))
+        assertEquals(DefaultGroovyMethods.trunc(bd, 3), new BigDecimal('1000.123'))
+        assertEquals(DefaultGroovyMethods.trunc(bd, 4), new BigDecimal('1000.1234'))
+        assertEquals(DefaultGroovyMethods.trunc(bd, 5), new BigDecimal('1000.12345'))
+        assertEquals(DefaultGroovyMethods.trunc(bd, 6), new BigDecimal('1000.123456'))
+
+        BigDecimal bd2 = new BigDecimal('-123.739')
+
+        assertEquals(DefaultGroovyMethods.trunc(bd2), new BigDecimal('-123.0'))
+        assertEquals(DefaultGroovyMethods.trunc(bd2, 0), new BigDecimal('-123.0'))
+        assertEquals(DefaultGroovyMethods.trunc(bd2, 1), new BigDecimal('-123.7'))
+        assertEquals(DefaultGroovyMethods.trunc(bd2, 2), new BigDecimal('-123.73'))
     }
 
     // GROOVY-6626


### PR DESCRIPTION
I tried to address the issues raised by @blackdrag in the original groovy/groovy-core#281 PR.  The `round` methods may be slightly confusing since the `BigDecimal#round(MathContext)` method works on  the entire number, so I tried to call that out in the javadoc.