### PR TITLE
GROOVY-7660: gradle/utils.gradle: Remove unused imports and unused variables. 

### DIFF
--- a/gradle/utils.gradle
+++ b/gradle/utils.gradle
@@ -17,13 +17,18 @@
  *  under the License.
  */
 
-import org.codehaus.groovy.classgen.AnnotationVisitor
-import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.FieldVisitor
-import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Label
 
-import static org.objectweb.asm.Opcodes.*
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC
+import static org.objectweb.asm.Opcodes.ACC_STATIC
+import static org.objectweb.asm.Opcodes.ACC_SUPER
+import static org.objectweb.asm.Opcodes.ALOAD
+import static org.objectweb.asm.Opcodes.ATHROW
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL
+import static org.objectweb.asm.Opcodes.RETURN
+import static org.objectweb.asm.Opcodes.V1_5
 
 buildscript {
     repositories {
@@ -45,9 +50,7 @@ task exceptionUtils {
 
     doLast {
         ClassWriter cw = new ClassWriter(0);
-        FieldVisitor fv;
         MethodVisitor mv;
-        AnnotationVisitor av0;
 
         cw.visit(V1_5, ACC_PUBLIC + ACC_SUPER, 'org/codehaus/groovy/runtime/ExceptionUtils', null, 'java/lang/Object', null);
 


### PR DESCRIPTION
This pull request remove unused imports and unused variables in gradle/utils.gradle. Also, instead of importing the whole namespace containing all ASM Opscode, we specify them one by one.