### PR TITLE
GROOVY-2178 - Shell can not handle multi-line list defs

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Parser.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Parser.groovy
@@ -181,7 +181,8 @@ final class RigidParser implements Parsing
                 // HACK: Super insane hack... we detect a syntax error, but might still ignore
                 // it depending on the line ending
                 if (ignoreSyntaxErrorForLineEnding(buffer[-1].trim()) ||
-                    isAnnotationExpression(e, buffer[-1].trim())) {
+                        isAnnotationExpression(e, buffer[-1].trim()) ||
+                        hasUnmatchedOpenBracketOrParen(source)) {
                     log.debug("Ignoring parse failure; might be valid: $e")
                 } else {
                     error = e
@@ -209,6 +210,25 @@ final class RigidParser implements Parsing
             }
         }
         return false
+    }
+
+    static boolean hasUnmatchedOpenBracketOrParen(String source) {
+        if (!source) {
+            return false
+        }
+        int parens = 0
+        int brackets = 0
+        for (ch in source) {
+            switch(ch) {
+                case '[': ++brackets; break;
+                case ']': --brackets; break;
+                case '(': ++parens; break;
+                case ')': --parens; break;
+                default:
+                    break
+            }
+        }
+        return (brackets > 0 || parens > 0)
     }
 
     static boolean isAnnotationExpression(CompilationFailedException e, String line) {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshParsersTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshParsersTest.groovy
@@ -36,4 +36,15 @@ class GroovyshParsersTest extends GroovyTestCase {
             assert RigidParser.isAnnotationExpression(mcee, '@Override')
         }
     }
+
+    void testHasUnmatchedOpenBracketOrParen() {
+        assert RigidParser.hasUnmatchedOpenBracketOrParen('a = [')
+        assert !RigidParser.hasUnmatchedOpenBracketOrParen('a = [1,2,3]')
+        assert !RigidParser.hasUnmatchedOpenBracketOrParen('a = 1,2,3]')
+
+        assert RigidParser.hasUnmatchedOpenBracketOrParen('myfunc(3')
+        assert !RigidParser.hasUnmatchedOpenBracketOrParen('myfunc(1,2,3)')
+        assert !RigidParser.hasUnmatchedOpenBracketOrParen('a = 1,2,3)')
+    }
+
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -97,6 +97,36 @@ class GroovyshTest extends GroovyTestCase {
         }
     }
 
+    void testIncompleteBracketMultilineExpr() {
+        Groovysh groovysh = createGroovysh()
+        groovysh.execute('a = [')
+        groovysh.execute('1,')
+        groovysh.execute('2,')
+        groovysh.execute('3')
+        groovysh.execute(']')
+        groovysh.execute('a.size() == 3')
+        assert mockOut.toString().contains('true')
+    }
+
+    void testIncompleteParenMultilineExpr() {
+        Groovysh groovysh = createGroovysh()
+        groovysh.execute('mc = { num1, num2 -> num1 + num2 }')
+        groovysh.execute('mc(3')
+        groovysh.execute(',')
+        groovysh.execute('7')
+        groovysh.execute(') == 10')
+        assert mockOut.toString().contains('true')
+    }
+
+    void testIncompleteBraceMultilineExpr() {
+        Groovysh groovysh = createGroovysh()
+        groovysh.execute('mc = {')
+        groovysh.execute('3')
+        groovysh.execute('}')
+        groovysh.execute('mc() == 3')
+        assert mockOut.toString().contains('true')
+    }
+
     void testMissingPropertyExpr() {
         Groovysh groovysh = createGroovysh()
         // this is a special case, e.g. happens for Gradle DefaultExtraPropertiesExtension


### PR DESCRIPTION
To address @blackdrag's comments on the issue, there was already some code that handles [detecting incomplete lines] (https://github.com/apache/incubator-groovy/blob/1eb37ea96428e14f0418fa003292cce9d3f94f94/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Parser.groovy#L204-L212) and it looks like it captures all the chars referenced in the comment.  I wasn't able to replicate the problem with opened braces `{` so am just trying to detect (if compilation error is thrown) if there's an unmatched bracket `[` or paren `(`.