### PR TITLE
GROOVY-7665 - JsonSlurperCharSource decimal parsing producing unexpected results

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/CharScanner.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/CharScanner.java
@@ -684,7 +684,7 @@ public class CharScanner {
     }
 
     public static BigDecimal parseBigDecimal(char[] buffer, int from, int to) {
-        return new BigDecimal(parseDouble(buffer, from, to));
+        return new BigDecimal(buffer, from, to);
     }
 
     public static float parseFloat(char[] buffer, int from, int to) {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperCharSourceTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperCharSourceTest.groovy
@@ -26,4 +26,10 @@ class JsonSlurperCharSourceTest extends JsonSlurperTest {
     void setUp() {
         parser = new JsonSlurper().setType(JsonParserType.CHARACTER_SOURCE)
     }
+
+    void testParsingDecimalValue() {
+        def num = parser.parseText('{"num": 123.40}').num
+        assert num instanceof BigDecimal
+        assert 123.40G == num
+    }
 }


### PR DESCRIPTION
Commit 842bcd4e23fefdf5b5e17d8d91af50e1ce565096 introduced the `BigDecimal` return types and reused some of the original parsing methods.  However, in this case I think it makes more sense to just let `BigDecimal` parse the text since converting first to a double can cause some odd results.