### PR TITLE
GROOVY-6922 - JsonSlurper loses trailing 0's in numbers

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/CharScanner.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/CharScanner.java
@@ -653,23 +653,8 @@ public class CharScanner {
             } else {
                 value = parseLongFromTo(buffer, from, index);
             }
-        } else if (foundDot && simple) {
-            BigDecimal lvalue;
-
-            if (length < powersOf10.length) {
-                if (isInteger(buffer, from, length)) {
-                    lvalue = new BigDecimal(parseIntFromToIgnoreDot(buffer, from, index));
-                } else {
-                    lvalue = new BigDecimal(parseLongFromToIgnoreDot(buffer, from, index));
-                }
-
-                BigDecimal power = new BigDecimal(powersOf10[digitsPastPoint]);
-                value = lvalue.divide(power);
-            } else {
-                value = new BigDecimal(new String(buffer, from, length));
-            }
         } else {
-            value = new BigDecimal(new String(buffer, from, index - from));
+            value = parseBigDecimal(buffer, from, length);
         }
 
         if (size != null) {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/internal/CharScannerTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/internal/CharScannerTest.groovy
@@ -624,6 +624,28 @@ class CharScannerTest extends GroovyTestCase {
         )
     }
 
+    void testParseJsonNumberToDecimal() {
+        def num = CharScanner.parseJsonNumber('123.40'.toCharArray())
+        assert num instanceof BigDecimal
+        assert num == 123.40G
+        assert num.scale() == 2
+
+        num = CharScanner.parseJsonNumber('-123.400'.toCharArray())
+        assert num instanceof BigDecimal
+        assert num == -123.400G
+        assert num.scale() == 3
+
+        num = CharScanner.parseJsonNumber('3.7e-5'.toCharArray())
+        assert num instanceof BigDecimal
+        assert num == 0.000037G
+        assert num.scale() == 6
+
+        num = CharScanner.parseJsonNumber('-1.25E+7'.toCharArray())
+        assert num instanceof BigDecimal
+        assert num == -12500000.0G
+        assert num.scale() == -5
+    }
+
     protected assertArrayEquals(char[] expected, char[] actual) {
         assertArrayEquals((Object[]) expected, (Object[]) actual)
     }


### PR DESCRIPTION
This change is dependent on the change made in commit 84467fddc64744cc05d2b91b8704c753a9fb3d04 in master to the [CharScanner#parseBigDecimal(char[],int,int)] (https://github.com/apache/incubator-groovy/commit/84467fddc64744cc05d2b91b8704c753a9fb3d04#diff-d0df59d6b1bac924a44389e6b41aac99R687) method.

The code being replaced looked like it was code left over from when the method returned a double for decimal values.  This change uses the [BigDecimal(char[],int,int)] (http://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html#BigDecimal(char[],%20int,%20int)) constructor (available since 1.5) for parsing of the decimal string and also eliminates the new String object allocations.