### PR TITLE
Fix javadoc malformed link warning

### DIFF
--- a/src/main/groovy/lang/ObjectRange.java
+++ b/src/main/groovy/lang/ObjectRange.java
@@ -71,7 +71,7 @@ public class ObjectRange extends AbstractList implements Range {
     }
 
     /**
-     * Creates a new {@link ObjectRange,} assumes smaller <= larger, else behavior is undefined.
+     * Creates a new {@link ObjectRange} assumes smaller <= larger, else behavior is undefined.
      * Caution: Prefer the other constructor when in doubt.
      *
      * Optimized Constructor avoiding initial computation of comparison.


### PR DESCRIPTION
src/main/groovy/lang/ObjectRange.java:79: warning - Tag @link: malformed: "ObjectRange,"

These warnings are emitted during gradle javadoc task.