### PR TITLE
GROOVY-7675 - Fix compilerCustomizationBuilder withConfig secureAst resolution

### DIFF
--- a/src/main/org/codehaus/groovy/control/customizers/builder/SecureASTCustomizerFactory.java
+++ b/src/main/org/codehaus/groovy/control/customizers/builder/SecureASTCustomizerFactory.java
@@ -47,6 +47,7 @@ public class SecureASTCustomizerFactory extends AbstractFactory {
         if (node instanceof SecureASTCustomizer) {
             Closure clone = (Closure) childContent.clone();
             clone.setDelegate(node);
+            clone.setResolveStrategy(Closure.DELEGATE_FIRST);
             clone.call();
         }
         return false;

--- a/src/test/org/codehaus/groovy/control/customizers/builder/CompilerCustomizationBuilderTest.groovy
+++ b/src/test/org/codehaus/groovy/control/customizers/builder/CompilerCustomizationBuilderTest.groovy
@@ -321,7 +321,6 @@ class CompilerCustomizationBuilderTest extends GroovyTestCase {
     }
 
     void testCompilerConfigurationBuilderStyle() {
-        println 'hello'
         def config = new CompilerConfiguration()
         // the "customizers" method is added through a custom metaclass
         CompilerCustomizationBuilder.withConfig(config) {
@@ -331,6 +330,16 @@ class CompilerCustomizationBuilderTest extends GroovyTestCase {
         def result = shell.evaluate '''class A { int x }
         new A(x:1).toString()'''
         assert result == 'A(1)'
+    }
+
+    void testCompilerConfigurationBuilderWithSecureAstCustomizer() {
+        def config = new CompilerConfiguration()
+        CompilerCustomizationBuilder.withConfig(config) {
+            secureAst {
+                importsWhitelist = []
+            }
+        }
+        assert config.compilationCustomizers.first().importsWhitelist == []
     }
 
     private static class SourceUnit {


### PR DESCRIPTION
I found this bug some moths ago, I forgot to create Jira. Maybe can happen in other config builders.