### PR TITLE
Fix too large padding-left to remove horizontal scollbar.

### DIFF
--- a/src/spec/assets/css/style.css
+++ b/src/spec/assets/css/style.css
@@ -880,7 +880,7 @@ p a > code:hover {
 
 @media only screen and (min-width: 768px) {
     body.toc2 {
-        padding-left: 17em;
+        padding-left: 2em;
         padding-right: 2em;
     }
 
@@ -932,7 +932,7 @@ p a > code:hover {
 
 @media only screen and (min-width: 1280px) {
     body.toc2 {
-        padding-left: 22em;
+        padding-left: 2em;
         padding-right: 2em;
     }
 


### PR DESCRIPTION
The Groovy Language Documentation has redundant scroll bar because of the large padding-left. The proper value of padding-left should be '2em'.
