### PR TITLE
GROOVY-7538 Bound unbounded wildcards using the type declaration

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -4216,7 +4216,9 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             GenericsUtils.extractPlaceholders(receiver, resolvedPlaceholders);
         }
         resolvePlaceholdersFromExplicitTypeHints(method, explicitTypeHints, resolvedPlaceholders);
-        if (resolvedPlaceholders.isEmpty()) return returnType;
+        if (resolvedPlaceholders.isEmpty()) {
+            return boundUnboundedWildcards(returnType);
+        }
         Map<String, GenericsType> placeholdersFromContext = extractGenericsParameterMapOfThis(typeCheckingContext.getEnclosingMethod());
         applyGenericsConnections(placeholdersFromContext,resolvedPlaceholders);
 

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -494,7 +494,7 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
             }
         }
         new ClassB()
-        ''', 'Cannot call <X> groovy.transform.stc.GenericsSTCTest$ClassA <Long>#bar(java.lang.Class <Long>) with arguments [java.lang.Class <java.lang.Object extends java.lang.Object>]'
+        ''', 'Cannot call <X> groovy.transform.stc.GenericsSTCTest$ClassA <Long>#bar(java.lang.Class <Long>) with arguments [java.lang.Class <? extends java.lang.Object>]'
     }
 
     // GROOVY-5516

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy7538Bug.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy7538Bug.groovy
@@ -18,19 +18,16 @@
  */
 package org.codehaus.groovy.classgen.asm.sc.bugs
 
-import groovy.transform.NotYetImplemented
 import groovy.transform.stc.StaticTypeCheckingTestCase
 import org.codehaus.groovy.classgen.asm.sc.StaticCompilationTestSupport
 
 class Groovy7538Bug extends StaticTypeCheckingTestCase implements StaticCompilationTestSupport {
-    @NotYetImplemented
     void testFluentSubTypeToSuperType() {
         assertScript '''import org.codehaus.groovy.classgen.asm.sc.bugs.support.Groovy7538Support
             Groovy7538Support.assertThat("true").isNotEmpty().isNotEqualTo("false")
         '''
     }
 
-    @NotYetImplemented
     void testFluentSuperTypeToSubType() {
         assertScript '''import org.codehaus.groovy.classgen.asm.sc.bugs.support.Groovy7538Support
             Groovy7538Support.assertThat("true").isNotEqualTo("false").isNotEmpty()


### PR DESCRIPTION
If there is a type declared with bounds, for example

    class NumberList<T extends Number> implements List<T>

but used with an unbounded wildcard

    NumberList<?> getList()

the bounds are actually implicit and need to be taken into account for the
static type checks, to be able to use the type of the parameter directly:

    getList()[0].longValue()

The type of the element is known to be `Number`, not `Object`.