### PR TITLE
GROOVY-7688 Spread safe method call receivers with side effects shoul…

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
@@ -446,12 +446,10 @@ public class StaticInvocationWriter extends InvocationWriter {
         }
         // if call is spread safe, replace it with a for in loop
         if (spreadSafe && origin instanceof MethodCallExpression) {
-            // List literals should not be visited twice, avoid by using a temporary variable for the receiver
-            if (receiver instanceof ListExpression) {
-                TemporaryVariableExpression tmp = new TemporaryVariableExpression(receiver);
-                makeCall(origin, tmp, message, arguments, adapter, true, true, false);
-                tmp.remove(controller);
-                return;
+            // receiver expressions with side effects should not be visited twice, avoid by using a temporary variable
+            Expression tmpReceiver = receiver;
+            if (!(receiver instanceof VariableExpression) && !(receiver instanceof ConstantExpression)) {
+                tmpReceiver = new TemporaryVariableExpression(receiver);
             }
             MethodVisitor mv = controller.getMethodVisitor();
             CompileStack compileStack = controller.getCompileStack();
@@ -475,13 +473,13 @@ public class StaticInvocationWriter extends InvocationWriter {
             declr.visit(controller.getAcg());
             operandStack.pop();
             // if (receiver != null)
-            receiver.visit(controller.getAcg());
+            tmpReceiver.visit(controller.getAcg());
             Label ifnull = compileStack.createLocalLabel("ifnull_" + counter);
             mv.visitJumpInsn(IFNULL, ifnull);
             operandStack.remove(1); // receiver consumed by if()
             Label nonull = compileStack.createLocalLabel("nonull_" + counter);
             mv.visitLabel(nonull);
-            ClassNode componentType = StaticTypeCheckingVisitor.inferLoopElementType(typeChooser.resolveType(receiver, classNode));
+            ClassNode componentType = StaticTypeCheckingVisitor.inferLoopElementType(typeChooser.resolveType(tmpReceiver, classNode));
             Parameter iterator = new Parameter(componentType, "for$it$" + counter);
             VariableExpression iteratorAsVar = new VariableExpression(iterator);
             MethodCallExpression origMCE = (MethodCallExpression) origin;
@@ -503,7 +501,7 @@ public class StaticInvocationWriter extends InvocationWriter {
             // for (e in receiver) { result.add(e?.method(arguments) }
             ForStatement stmt = new ForStatement(
                     iterator,
-                    receiver,
+                    tmpReceiver,
                     new ExpressionStatement(add)
             );
             stmt.visit(controller.getAcg());
@@ -513,6 +511,11 @@ public class StaticInvocationWriter extends InvocationWriter {
             // end of if/else
             // return result list
             result.visit(controller.getAcg());
+
+            // cleanup temporary variables
+            if (tmpReceiver instanceof TemporaryVariableExpression) {
+                ((TemporaryVariableExpression) tmpReceiver).remove(controller);
+            }
         } else if (safe && origin instanceof MethodCallExpression) {
             // wrap call in an IFNULL check
             MethodVisitor mv = controller.getMethodVisitor();

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesStatementWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesStatementWriter.java
@@ -145,6 +145,9 @@ public class StaticTypesStatementWriter extends StatementWriter {
 
         mv.visitLabel(breakLabel);
 
+        compileStack.removeVar(loopIdx);
+        compileStack.removeVar(arrayLen);
+        compileStack.removeVar(array);
     }
 
     private void loadFromArray(MethodVisitor mv, BytecodeVariable variable, int array, int iteratorIdx) {

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/ArraysAndCollectionsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/ArraysAndCollectionsStaticCompileTest.groovy
@@ -110,6 +110,24 @@ class ArraysAndCollectionsStaticCompileTest extends ArraysAndCollectionsSTCTest 
         '''
     }
 
+    //GROOVY-7688
+    void testSpreadSafeMethodCallReceiversWithSideEffectsShouldNotBeVisitedTwice() {
+        try {
+            assertScript '''
+                class Foo {
+                    static void test() {
+                        def list = ['a', 'b']
+                        def lengths = list.toList()*.length()
+                        assert lengths == [1, 1]
+                    }
+                }
+                Foo.test()
+            '''
+        } finally {
+            assert astTrees['Foo'][1].count('DefaultGroovyMethods.toList') == 1
+        }
+    }
+
     @Override
     void testForInLoop() {
         try {


### PR DESCRIPTION
…d not be visited twice

* StaticInvocationWriter#makeCall: use temporary variables for spread safe receiver expressions which are not variable or constant expressions
* StaticTypesStatementWriter#writeOptimizedForEachLoop: remove temporary variables from compileStack after their use